### PR TITLE
refactor: split http gateway into seperate command

### DIFF
--- a/internal/command/flags/flags.go
+++ b/internal/command/flags/flags.go
@@ -1,0 +1,34 @@
+package flags
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/weaveworks/reignite/internal/config"
+	"github.com/weaveworks/reignite/pkg/defaults"
+)
+
+const (
+	grpcEndpointFlag = "grpc-endpoint"
+	httpEndpointFlag = "http-endpoint"
+)
+
+// AddGRPCServerFlagsToCommand will add gRPC server flags to the supplied command.
+func AddGRPCServerFlagsToCommand(cmd *cobra.Command, cfg *config.Config) {
+	cmd.Flags().StringVar(&cfg.GRPCAPIEndpoint,
+		grpcEndpointFlag,
+		defaults.GRPCAPIEndpoint,
+		"The endpoint for the gRPC server to listen on.")
+}
+
+// AddGWServerFlagsToCommand will add gRPC HTTP gateway flags to the supplied command.
+func AddGWServerFlagsToCommand(cmd *cobra.Command, cfg *config.Config) {
+	cmd.Flags().StringVar(&cfg.GRPCAPIEndpoint,
+		grpcEndpointFlag,
+		defaults.GRPCAPIEndpoint,
+		"The address of the gRPC server to act as a gateway for.")
+
+	cmd.Flags().StringVar(&cfg.HTTPAPIEndpoint,
+		httpEndpointFlag,
+		defaults.HTTPAPIEndpoint,
+		"The endpoint for the HTTP proxy to the gRPC service to listen on.")
+}

--- a/internal/command/gw/gw.go
+++ b/internal/command/gw/gw.go
@@ -1,0 +1,126 @@
+package gw
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+
+	mvmv1 "github.com/weaveworks/reignite/api/services/microvm/v1alpha1"
+	cmdflags "github.com/weaveworks/reignite/internal/command/flags"
+	"github.com/weaveworks/reignite/internal/config"
+	"github.com/weaveworks/reignite/pkg/flags"
+	"github.com/weaveworks/reignite/pkg/log"
+)
+
+// NewCommand creates a new cobra command for running the gRPC HTTP gateway.
+func NewCommand(cfg *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "gw",
+		Short: "Start serving the HTTP gateway for the reignite gRPC API",
+		PreRunE: func(c *cobra.Command, _ []string) error {
+			flags.BindCommandToViper(c)
+
+			return nil
+		},
+		RunE: func(c *cobra.Command, _ []string) error {
+			return runGWServer(c.Context(), cfg)
+		},
+	}
+
+	cmdflags.AddGWServerFlagsToCommand(cmd, cfg)
+
+	return cmd
+}
+
+func runGWServer(ctx context.Context, cfg *config.Config) error {
+	logger := log.GetLogger(ctx)
+	logger.Info("reignited grpc api gateway starting")
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+
+	wg := &sync.WaitGroup{}
+	ctx, cancel := context.WithCancel(log.WithLogger(ctx, logger))
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := serveAPI(ctx, cfg); err != nil {
+			logger.Errorf("failed serving api: %v", err)
+		}
+	}()
+
+	<-sigChan
+	logger.Debug("shutdown signal received, waiting for work to finish")
+
+	cancel()
+	wg.Wait()
+
+	logger.Info("all work finished, exiting")
+
+	return nil
+}
+
+func serveAPI(ctx context.Context, cfg *config.Config) error {
+	logger := log.GetLogger(ctx)
+	mux := runtime.NewServeMux()
+
+	// TODO: create the dependencies for the server
+
+	// grpcServer := grpc.NewServer(
+	// 	grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
+	// 	grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
+	// )
+	// mvmv1.RegisterMicroVMServer(grpcServer, server.NewServer())
+	// grpc_prometheus.Register(grpcServer)
+	// http.Handle("/metrics", promhttp.Handler())
+
+	opts := []grpc.DialOption{
+		grpc.WithInsecure(),
+	}
+
+	if err := mvmv1.RegisterMicroVMHandlerFromEndpoint(ctx, mux, cfg.GRPCAPIEndpoint, opts); err != nil {
+		return fmt.Errorf("could not register microvm server: %w", err)
+	}
+
+	s := &http.Server{
+		Addr:    cfg.HTTPAPIEndpoint,
+		Handler: mux,
+	}
+
+	go func() {
+		<-ctx.Done()
+		logger.Infof("shutting down the http gateway server")
+		if err := s.Shutdown(context.Background()); err != nil {
+			logger.Errorf("failed to shutdown http gateway server: %v", err)
+		}
+		// logger.Infof("shutting down grpc server")
+		// grpcServer.GracefulStop()
+	}()
+
+	// logger.Debugf("starting grpc server listening on endpoint %s", cfg.GRPCAPIEndpoint)
+	// l, err := net.Listen("tcp", cfg.GRPCAPIEndpoint)
+	// if err != nil {
+	// 	return fmt.Errorf("setting up gRPC api listener: %w", err)
+	// }
+	// defer l.Close()
+	// go func() {
+	// 	if err := grpcServer.Serve(l); err != nil {
+	// 		logger.Fatalf("serving grpc api: %v", err) // TODO: remove this fatal
+	// 	}
+	// }()
+
+	logger.Debugf("starting http server listening on endpoint %s", cfg.HTTPAPIEndpoint)
+	if err := s.ListenAndServe(); err != nil {
+		return fmt.Errorf("listening and serving http api: %w", err)
+	}
+
+	return nil
+}

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -7,13 +7,16 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/weaveworks/reignite/internal/command/gw"
+	"github.com/weaveworks/reignite/internal/command/run"
+	"github.com/weaveworks/reignite/internal/config"
 	"github.com/weaveworks/reignite/pkg/defaults"
 	"github.com/weaveworks/reignite/pkg/flags"
 	"github.com/weaveworks/reignite/pkg/log"
 )
 
 func NewRootCommand() (*cobra.Command, error) {
-	cfg := &Config{}
+	cfg := &config.Config{}
 
 	cmd := &cobra.Command{
 		Use:   "reignited",
@@ -54,7 +57,10 @@ func initCobra() {
 	viper.ReadInConfig() //nolint: errcheck
 }
 
-func addRootSubCommands(cmd *cobra.Command, cfg *Config) {
-	runCmd := newRunCommand(cfg)
+func addRootSubCommands(cmd *cobra.Command, cfg *config.Config) {
+	runCmd := run.NewCommand(cfg)
 	cmd.AddCommand(runCmd)
+
+	gwCmd := gw.NewCommand(cfg)
+	cmd.AddCommand(gwCmd)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,4 @@
-package command
+package config
 
 import (
 	"github.com/weaveworks/reignite/pkg/log"


### PR DESCRIPTION
**What this PR does / why we need it**:

The running of the gRPC gateway has been split out into a separate command so that it becomes an optional component.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #52 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Remove the gRPC HTTP gateway into a separate command.
```