### PR TITLE
fix: titlecheck action fails

### DIFF
--- a/.github/workflows/titlecheck.yml
+++ b/.github/workflows/titlecheck.yml
@@ -1,12 +1,6 @@
 name: titlecheck
 
-on:
-  pull_request:
-    types:
-      - opened
-      - edited
-      - synchronize
-      - reopened
+on: [pull_request_target]
 
 jobs:
   titlecheck:


### PR DESCRIPTION
The title check action fails with the following error:

```
Error: Resource not accessible by integration
```

Looking at [this](https://github.community/t/github-actions-are-severely-limited-on-prs/18179/15) it appears the fix is to change the event source.

Signed-off-by: Richard Case <richard@weave.works>

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Change the event type for the title check GHA.
```