### PR TITLE
chore: add labels to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "kind/cleanup"
+      - "area/dependency"

--- a/.github/workflows/pr_type.yml
+++ b/.github/workflows/pr_type.yml
@@ -16,5 +16,5 @@ jobs:
     steps:
       - uses: docker://agilepathway/pull-request-label-checker:latest
         with:
-          one_of: kind/bug,kind/documentation,kind/feature,kind/regression,kind/refactor
+          one_of: kind/bug,kind/documentation,kind/feature,kind/regression,kind/refactor,kind/cleanup
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


**What this PR does / why we need it**:
Changed the dependabot configuration so that it adds labels to the PRs it creates.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Add labels to dependabot PRs.
```