### PR TITLE
fix infrastructure/containerd integration tests

### DIFF
--- a/infrastructure/containerd/image_service_test.go
+++ b/infrastructure/containerd/image_service_test.go
@@ -84,9 +84,15 @@ func TestImageService_Integration(t *testing.T) {
 	Expect(len(leases)).To(Equal(1))
 	Expect(leases[0].ID).To(Equal(expectedLeaseName), "expect lease with name %s to exists", expectedLeaseName)
 
-	inputGet.ImageName = "docker.io/linuxkit/kernel:5.4.129"
+	inputGet.ImageName = testImageKernel
 
 	err = imageSvc.Pull(ctx, inputGet)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = client.ImageService().Delete(namespaceCtx, testImageKernel)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = client.ImageService().Delete(namespaceCtx, testImageVolume)
 	Expect(err).NotTo(HaveOccurred())
 }
 

--- a/infrastructure/containerd/repo_test.go
+++ b/infrastructure/containerd/repo_test.go
@@ -92,6 +92,9 @@ func TestMicroVMRepo_Integration_MultipleSave(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(savedVM).NotTo(BeNil())
 	Expect(savedVM.Version).To(Equal(2))
+
+	err = repo.Delete(ctx, testVm)
+	Expect(err).NotTo(HaveOccurred())
 }
 
 func makeSpec(name, ns string) *models.MicroVM {


### PR DESCRIPTION
**What this PR does / why we need it**:

* Clean up at the end of TestImageService_Integration.
* Clean up at the end of TestMicroVMRepo_Integration_MultipleSave.

**Which issue(s) this PR fixes**

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits
- [x] adds or updates unit tests

**Release note**:
```release-note
Fix infrastructure/containerd integration tests
```