### PR TITLE
Fix go generate

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1443,6 +1443,7 @@ golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3 h1:L69ShwSZEyCsLKoAxDKeMvLDZkumEe8gXUZAjab0tX8=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/inject/wire_gen.go
+++ b/internal/inject/wire_gen.go
@@ -8,7 +8,6 @@ package inject
 
 import (
 	"fmt"
-
 	"github.com/spf13/afero"
 	"github.com/weaveworks/reignite/core/application"
 	"github.com/weaveworks/reignite/core/ports"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix `go generate`

```
❯ make generate-go
go generate ./...
/home/efertone/go/pkg/mod/github.com/google/wire@v0.5.0/internal/wire/copyast.go:21:2: missing go.sum entry for module providing package golang.org/x/tools/go/ast/astutil (imported by github.
com/google/wire/internal/wire); to add:
        go get github.com/google/wire/internal/wire@v0.5.0
/home/efertone/go/pkg/mod/github.com/google/wire@v0.5.0/internal/wire/parse.go:30:2: missing go.sum entry for module providing package golang.org/x/tools/go/packages (imported by github.com/g
oogle/wire/internal/wire); to add:
        go get github.com/google/wire/internal/wire@v0.5.0
/home/efertone/go/pkg/mod/github.com/google/wire@v0.5.0/internal/wire/analyze.go:26:2: missing go.sum entry for module providing package golang.org/x/tools/go/types/typeutil (imported by gith
ub.com/google/wire/cmd/wire); to add:
        go get github.com/google/wire/cmd/wire@v0.5.0
internal/inject/wire_gen.go:3: running "go": exit status 1
make: *** [Makefile:73: generate-go] Error 1
```

**Which issue(s) this PR fixes**:
Fixes #125

**Checklist**:

- [x] squashed commits into logical changes
