### PR TITLE
fix: check instance state before starting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/containerd/containerd v1.5.5
 	github.com/containerd/typeurl v1.0.2
 	github.com/firecracker-microvm/firecracker-go-sdk v0.22.0
+	github.com/go-openapi/strfmt v0.19.5 // indirect
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.3.0 // indirect

--- a/infrastructure/firecracker/types.go
+++ b/infrastructure/firecracker/types.go
@@ -158,3 +158,15 @@ type VsockDeviceConfig struct {
 type Metadata struct {
 	Latest map[string]string `json:"latest"`
 }
+
+// InstanceState is a type that represents the running state of a Firecracker instance.
+type InstanceState string
+
+var (
+	// InstanceStateNotStarted the instance hasn't started running yet.
+	InstanceStateNotStarted InstanceState = "Not Started"
+	// InstanceStateStarted the instance is running.
+	InstanceStateStarted InstanceState = "Started"
+	// InstanceStatePaused the instance is currently paused.
+	InstanceStatePaused InstanceState = "Paused"
+)


### PR DESCRIPTION
**What this PR does / why we need it**:

When starting a Firecracker instance we should check that state of the
instance using the Firecracker API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #130 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
