### PR TITLE
ci: ensure nightly builds actually runs

### DIFF
--- a/.github/workflows/nightly_e2e.yml
+++ b/.github/workflows/nightly_e2e.yml
@@ -13,10 +13,16 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '^1.16.2'
-    - uses: hashicorp-terraform@v1
+    - uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 1.0.1
+        terraform_version: 1.0.9
+        terraform_wrapper: false
     - name: Run tests
       run: make test-e2e
       env:
         METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}
+    - name: Cleanup projects
+      uses: weaveworks/metal-janitor-action@b0373b3a6a8bb1e6573616040121c22ba230cdc8
+      with:
+        metal_auth_token: ${{ secrets.METAL_AUTH_TOKEN }}
+        project_names: 'quicksilver_e2e_1'

--- a/test/e2e/infra/main.tf
+++ b/test/e2e/infra/main.tf
@@ -39,7 +39,7 @@ provider "metal" {
 }
 
 resource "metal_project" "quicksilver_e2e" {
-   name = "quicksilver_e2e"
+   name = "quicksilver_e2e_1"
 }
 
 resource "metal_project_ssh_key" "test" {
@@ -68,7 +68,6 @@ resource "null_resource" "example_provisioner" {
         user = var.ssh_user
         port = var.ssh_port
         private_key = file(var.private_key_path)
-        agent = true
     }
 
     provisioner "file" {


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
-->

**What this PR does / why we need it**:

Fixes the e2e nightlies, it appears they never actually had a successful run.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #127 
