### PR TITLE
Try to fix EventService test failures

### DIFF
--- a/infrastructure/containerd/event_service_test.go
+++ b/infrastructure/containerd/event_service_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/weaveworks/reignite/api/events"
 	"github.com/weaveworks/reignite/core/ports"
@@ -106,8 +105,8 @@ func newSubscriber(t *testing.T, rootContext context.Context, data subData) {
 	recvd, err := watch(t, &subscriber, data.MaxEvents)
 	t.Logf("subscriber (%d) is done", data.ID)
 
-	assert.NoError(t, err)
-	assert.Len(t, recvd, data.MaxEvents)
+	Expect(err).To(BeNil())
+	Expect(recvd).To(HaveLen(data.MaxEvents))
 
 	data.Done()
 }


### PR DESCRIPTION


I was able to reproduce the issue with a helping had from cgroup.
Limiting to one CPU with a heavily quota (0.01% of my CPU) revealed the
issue.

Note before I describe what happened:
Containerd does not send messages to subscribers retrospectively, all
subscribers will receive events from the point they subscribed.

The original test created published N events and after that created
subscribers. The connection between the test and containerd is much
slower than the execution of the test, so when containrd wants to send
out the events to all subscribers, they are already there to receive
events. That's why it works on my machine and that's why it can pass on
Github Actions sometimes.

However, on a slow machine, with only one vcpu, the test and containerd
are racing for their own cpu share. In this scenario, the events are
already published before the subscribers are ready to receive them.

Solution:
Create subscribers first and then publish events.

Disclaimer:
There is a chance, all I wrote above is not entire correct, but that's
how I understand it. It does not really matter if we only check the
logic in the test. Originally it was publish->subscribe, but it's not
correct, we need subscribers before we publish events.

Fixes #115

**Checklist**:

- [x] squashed commits into logical changes
- [x] includes documentation
