### PR TITLE
Fix nil pointer dereference on CreateVM

### DIFF
--- a/infrastructure/firecracker/config.go
+++ b/infrastructure/firecracker/config.go
@@ -157,14 +157,26 @@ func ApplyConfig(ctx context.Context, cfg *VmmConfig, client *firecracker.Client
 			return fmt.Errorf("putting %s network configuration: %w", guestIfaceName, err)
 		}
 	}
-	_, err = client.PutGuestBootSource(ctx, &fcmodels.BootSource{
+
+	bootSource := fcmodels.BootSource{
+		BootArgs:        "",
+		InitrdPath:      "",
 		KernelImagePath: &cfg.BootSource.KernelImagePage,
-		BootArgs:        *cfg.BootSource.BootArgs,
-		InitrdPath:      *cfg.BootSource.InitrdPath,
-	})
+	}
+
+	if cfg.BootSource.BootArgs != nil {
+		bootSource.BootArgs = *cfg.BootSource.BootArgs
+	}
+
+	if cfg.BootSource.InitrdPath != nil {
+		bootSource.InitrdPath = *cfg.BootSource.InitrdPath
+	}
+
+	_, err = client.PutGuestBootSource(ctx, &bootSource)
 	if err != nil {
 		return fmt.Errorf("failed to put machine bootsource: %w", err)
 	}
+
 	if cfg.Logger != nil {
 		_, err = client.PutLogger(ctx, &fcmodels.Logger{
 			LogPath:       &cfg.Logger.LogPath,


### PR DESCRIPTION
**What this PR does / why we need it**:

The system does not allow to create a VM with both rootfs and initrd
specified, that means we should be able to create a vm without initrd,
but the code had some strange assumption about that:

       160:         _, err = client.PutGuestBootSource(ctx, &fcmodels.BootSource{
       161:                 KernelImagePath: &cfg.BootSource.KernelImagePage,
       162:                 BootArgs:        *cfg.BootSource.BootArgs,
    => 163:                 InitrdPath:      *cfg.BootSource.InitrdPath,
       164:         })

At the same time, it can happen with BootArgs too as it's not a required
field.

**Which issue(s) this PR fixes**:

Fixes #175

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
