### PR TITLE
fix: incorrect binary name in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
             - name: Download flintlock binaries
               uses: actions/download-artifact@v2
               with:
-                name: mccp-binaries
+                name: flintlock-binaries
                 path: bin
             - name: Generate release notes
               run: |


### PR DESCRIPTION
**What this PR does / why we need it**:

Changed the name of the binaries to retrieve after the build during the
release workflow as it was incorrect.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

