### PR TITLE
feat: add version subcommand

### DIFF
--- a/internal/command/gw/gw.go
+++ b/internal/command/gw/gw.go
@@ -15,6 +15,7 @@ import (
 	mvmv1 "github.com/weaveworks/flintlock/api/services/microvm/v1alpha1"
 	cmdflags "github.com/weaveworks/flintlock/internal/command/flags"
 	"github.com/weaveworks/flintlock/internal/config"
+	"github.com/weaveworks/flintlock/internal/version"
 	"github.com/weaveworks/flintlock/pkg/flags"
 	"github.com/weaveworks/flintlock/pkg/log"
 )
@@ -26,6 +27,14 @@ func NewCommand(cfg *config.Config) *cobra.Command {
 		Short: "Start serving the HTTP gateway for the flintlock gRPC API",
 		PreRunE: func(c *cobra.Command, _ []string) error {
 			flags.BindCommandToViper(c)
+
+			logger := log.GetLogger(c.Context())
+			logger.Infof(
+				"flintlockd, version=%s, built_on=%s, commit=%s",
+				version.Version,
+				version.BuildDate,
+				version.CommitHash,
+			)
 
 			return nil
 		},

--- a/internal/command/run/run.go
+++ b/internal/command/run/run.go
@@ -19,6 +19,7 @@ import (
 	cmdflags "github.com/weaveworks/flintlock/internal/command/flags"
 	"github.com/weaveworks/flintlock/internal/config"
 	"github.com/weaveworks/flintlock/internal/inject"
+	"github.com/weaveworks/flintlock/internal/version"
 	"github.com/weaveworks/flintlock/pkg/defaults"
 	"github.com/weaveworks/flintlock/pkg/flags"
 	"github.com/weaveworks/flintlock/pkg/log"
@@ -31,6 +32,14 @@ func NewCommand(cfg *config.Config) (*cobra.Command, error) {
 		Short: "Start running the flintlock API",
 		PreRunE: func(c *cobra.Command, _ []string) error {
 			flags.BindCommandToViper(c)
+
+			logger := log.GetLogger(c.Context())
+			logger.Infof(
+				"flintlockd, version=%s, built_on=%s, commit=%s",
+				version.Version,
+				version.BuildDate,
+				version.CommitHash,
+			)
 
 			return nil
 		},

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,5 +1,9 @@
 package version
 
+// PackageName is the name of the package, not just FlintlockD,
+// all commands fall under this name.
+const PackageName = "flintlock"
+
 var (
 	Version    = "undefined" // Specifies the app version
 	BuildDate  = "undefined" // Specifies the build date


### PR DESCRIPTION
**What this PR does / why we need it**:

The `version` subcommand without any flags prints out a general version
information, good to check what version we have.

    ❯ ./bin/flintlockd_amd64 version
    flintlock v0.1.0-alpha.1-11-af7a1a9

The `version` subcommand with `--short` flag prints out only the
version, useful for scripting.

    ❯ ./bin/flintlockd_amd64 version --short
    v0.1.0-alpha.1-11-af7a1a9

The `version` subcommand with `--long` flag prints out a detailed version
information, useful for bug reports.

    ❯ ./bin/flintlockd_amd64 version --long
    flintlock
      Version:    v0.1.0-alpha.1-12-gaf7a1a9
      CommitHash: af7a1a9
      BuildDate:  2021-11-03T11:38:43Z

== Why a subcommand and not a `-v` or `-V` flag?

Because it can be confusing. Some applications are using `-v` for
version, some are using `-V` for version because `-v` is the verbose
flag. Go, kubectl, and Helm follows the same logic, they have a
`version` subcommand.

**Different flags**

* I find it annoying to parse version information from `version`
  subcommands all the time when I want to automate something, that's the
  `--short`.
* I find it useful to print out everything we have for debugging or
  filing bug reports, that's the `--long` flag.
* I find it useful to print out the package/application name, so even if
  the binary was renamed I can see what is the name of the application,
  but without extra information like commit hash or build date.  That's
  the no-flag option.

**Moved the log.Info call**

In general, it's useful to print out the info log on `run` and `gw`, but
not for `version`.


**Which issue(s) this PR fixes**:
Fixes #163 

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
