### PR TITLE
chore: remove the message on XL pr

### DIFF
--- a/.github/workflows/pr_size.yml
+++ b/.github/workflows/pr_size.yml
@@ -15,4 +15,3 @@ jobs:
           m_max_size: '1500'
           l_max_size: '5000'
           fail_if_xl: 'false'
-          message_if_xl: 'This PR is so big! Please, split it 😊'


### PR DESCRIPTION
**What this PR does / why we need it**:

This change removes the configured message when a PR is an XL size. This
is generating a lot of noise on PRs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

