### PR TITLE
Ensure that test failures cause CI failure

### DIFF
--- a/test/tools/metal.py
+++ b/test/tools/metal.py
@@ -123,10 +123,10 @@ class Welder():
 
       self.logger.info(f"device {device.hostname} (id: {device.id}) ready")
 
-   def run_ssh_command(self, cmd, cwd):
+   def run_ssh_command(self, cmd, cwd, allow_error=True):
       shell = self.new_shell(self.ip)
       with shell:
-         result = shell.run(command=cmd, cwd=cwd, stdout=sys.stdout.buffer, stderr=sys.stderr.buffer, allow_error=True)
+         result = shell.run(command=cmd, cwd=cwd, stdout=sys.stdout.buffer, stderr=sys.stderr.buffer, allow_error=allow_error)
       self.logger.info("command exited with code %d", result.return_code)
 
    def delete_all(self, project, device, key):

--- a/test/tools/test.py
+++ b/test/tools/test.py
@@ -28,7 +28,7 @@ class Test:
 
     def run_tests(self):
         cmd = ['make', 'test-e2e']
-        self.welder.run_ssh_command(cmd, "/root/work/flintlock")
+        self.welder.run_ssh_command(cmd, "/root/work/flintlock", False)
 
     def teardown(self):
         self.welder.delete_all(self.project, self.device, self.key)


### PR DESCRIPTION
Extend the `run_ssh_command` method in the python test tool to pass in a value to allow/disallow
errors being recognised from the executed command

closes https://github.com/weaveworks/flintlock/issues/214
