### PR TITLE
Disable root volume validation

### DIFF
--- a/hack/scripts/payload/CreateMicroVM.json
+++ b/hack/scripts/payload/CreateMicroVM.json
@@ -20,7 +20,7 @@
     "volumes": [
       {
         "id": "root",
-        "is_root": false,
+        "is_root": true,
         "is_read_only": false,
         "mount_point": "/",
         "source": {

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -96,10 +96,4 @@ func customMicroVMSpecStructLevelValidation(sl validator.StructLevel) {
 
 		return
 	}
-
-	if spec.Initrd != nil && found {
-		sl.ReportError(spec.Volumes, "volumes", "Volumes", "noRootVolumeIfInitrdSpecified", "")
-
-		return
-	}
 }

--- a/pkg/validation/validate_test.go
+++ b/pkg/validation/validate_test.go
@@ -46,6 +46,18 @@ func TestValidation_Invalid(t *testing.T) {
 		},
 	}
 
+	tooManyRoots := basicMicroVM
+	tooManyRoots.Spec.Volumes = models.Volumes{
+		{
+			IsRoot:     true,
+			MountPoint: "/",
+		},
+		{
+			IsRoot:     true,
+			MountPoint: "/",
+		},
+	}
+
 	tt := []struct {
 		name      string
 		numErrors int
@@ -75,6 +87,11 @@ func TestValidation_Invalid(t *testing.T) {
 			name:      "should fail validation when no volumes are marked as root",
 			numErrors: 1,
 			vmspec:    invalidVolumes,
+		},
+		{
+			name:      "should fail validation when more than one volume is marked as root",
+			numErrors: 1,
+			vmspec:    tooManyRoots,
 		},
 	}
 

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -102,7 +102,7 @@ func defaultTestMicroVM(name, namespace string) *types.MicroVMSpec {
 		Volumes: []*types.Volume{
 			{
 				Id:         "root",
-				IsRoot:     false,
+				IsRoot:     true,
 				IsReadOnly: true,
 				MountPoint: "/",
 				Source: &types.VolumeSource{


### PR DESCRIPTION
The firecracker docs say that only you can only specify either a root
volume or an initrd. However, when we remove the root volume and only
have initrd (or vice-versa) the mvm will not start. 🤷‍♀️ 

We are not entirely sure what is happening yet, so for now we are going
to disable the validation and continue using both a root vol and
initrd. It's more of a guideline than an actual rule anyway 😉 

There is a separate ticket to track the investigation and potential fix
here: https://github.com/weaveworks/flintlock/issues/219

(Also added a missing test, the removed bit also was not covered so we
should remember to add one when/if we put it back)


**What this PR does / why we need it**:

Disables a volume validation check for the timebeing while we figure out the above issue. If we leave it in then we will be annoyed by all the failing.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [x] adds or updates e2e tests
