### PR TITLE
fix: ensure create plan is executed once

### DIFF
--- a/core/plans/microvm_create_update.go
+++ b/core/plans/microvm_create_update.go
@@ -52,6 +52,7 @@ func (p *microvmCreateOrUpdatePlan) Create(ctx context.Context) ([]planner.Proce
 		return []planner.Procedure{}, nil
 	}
 
+	p.clearPlanList()
 	p.ensureStatus()
 
 	var err error
@@ -70,6 +71,14 @@ func (p *microvmCreateOrUpdatePlan) Create(ctx context.Context) ([]planner.Proce
 
 func (p *microvmCreateOrUpdatePlan) Result() interface{} {
 	return nil
+}
+
+// This is the most important function in the codebase DO NOT REMOVE
+// Without this, the Create will always return the full origin list of steps
+// and the State will never be saved, meaning the steps will always return true
+// on ShouldDo. The loop will be infinite.
+func (p *microvmCreateOrUpdatePlan) clearPlanList() {
+	p.steps = []planner.Procedure{}
 }
 
 func (p *microvmCreateOrUpdatePlan) create(ctx context.Context, ports *ports.Collection) error {

--- a/core/plans/microvm_delete.go
+++ b/core/plans/microvm_delete.go
@@ -56,7 +56,7 @@ func (p *microvmDeletePlan) Create(ctx context.Context) ([]planner.Procedure, er
 		return []planner.Procedure{}, nil
 	}
 
-	p.steps = []planner.Procedure{}
+	p.clearPlanList()
 
 	// MicroVM provider delete
 	if err := p.addStep(ctx, microvm.NewDeleteStep(p.vm, ports.Provider)); err != nil {
@@ -96,6 +96,14 @@ func (p *microvmDeletePlan) Create(ctx context.Context) ([]planner.Procedure, er
 // Result is the result of the plan.
 func (p *microvmDeletePlan) Result() interface{} {
 	return nil
+}
+
+// This is the most important function in the codebase DO NOT REMOVE
+// Without this, the Delete will always return the full origin list of steps
+// and the State will never be saved, meaning the steps will always return true
+// on ShouldDo. The loop will be infinite.
+func (p *microvmDeletePlan) clearPlanList() {
+	p.steps = []planner.Procedure{}
 }
 
 func (p *microvmDeletePlan) addStep(ctx context.Context, step planner.Procedure) error {

--- a/core/steps/microvm/create.go
+++ b/core/steps/microvm/create.go
@@ -30,6 +30,12 @@ func (s *createStep) Name() string {
 }
 
 func (s *createStep) ShouldDo(ctx context.Context) (bool, error) {
+	logger := log.GetLogger(ctx).WithFields(logrus.Fields{
+		"step": s.Name(),
+		"vmid": s.vm.ID,
+	})
+	logger.Debug("checking if procedure should be run")
+
 	state, err := s.vmSvc.State(ctx, s.vm.ID.String())
 	if err != nil {
 		return false, fmt.Errorf("checking if microvm is running: %w", err)

--- a/core/steps/microvm/start.go
+++ b/core/steps/microvm/start.go
@@ -31,6 +31,12 @@ func (s *startStep) Name() string {
 }
 
 func (s *startStep) ShouldDo(ctx context.Context) (bool, error) {
+	logger := log.GetLogger(ctx).WithFields(logrus.Fields{
+		"step": s.Name(),
+		"vmid": s.vm.ID,
+	})
+	logger.Debug("checking if procedure should be run")
+
 	state, err := s.vmSvc.State(ctx, s.vm.ID.String())
 	if err != nil {
 		return false, fmt.Errorf("checking if microvm is running: %w", err)


### PR DESCRIPTION
The plan list must be cleared from memory between runs so that the plan
completes and the state is saved. This keeps us from falling into an
infinite loop.

Done as a function to emphasise importance!

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
-->

Fixes https://github.com/weaveworks/flintlock/issues/213


**Special notes for your reviewer**:
You are all very special

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
