### PR TITLE
Add action to run e2es on PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,15 @@
+name: run e2e tests
+
+on: [pull_request]
+
+jobs:
+  test:
+    name: test-e2e
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
+      - name: E2E tests in container
+        run: make test-e2e-docker

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,5 +11,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.17'
+      - name: debug
+        uses: mxschmitt/action-tmate@v3
       - name: E2E tests in container
         run: make test-e2e-docker


### PR DESCRIPTION
The e2es when run in docker are currently light and fast enough to be
run as part of a PR cycle, so it would be useful to do that.

Not merging for a sec as I look into something weird.