### PR TITLE
fix: set mac address for macvtap if specified

### DIFF
--- a/core/steps/network/interface_create.go
+++ b/core/steps/network/interface_create.go
@@ -88,10 +88,6 @@ func (s *createInterface) Do(ctx context.Context) ([]planner.Procedure, error) {
 		return nil, fmt.Errorf("checking if networking interface exists: %w", err)
 	}
 	if exists {
-		// This whole block is unreachable right now, because
-		// the Do function is called only if ShouldDo returns
-		// true. It retruns false if IfaceExists returns true.
-		// Line 76 will never return exists=true
 		details, err := s.svc.IfaceDetails(ctx, deviceName)
 		if err != nil {
 			return nil, fmt.Errorf("getting interface details: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a problem with using an auto generated mac address with a macvtap interface. The
kernel appears to change the mac address from what it was originally
created with. The firecracker and cloud init configuration contain the original mac address.
When the guest boots and cloud-init gets to configure the network the
mac address has changed and this then causes the network configuration to fail as it can't
match on the mac address.

We need to find actual evidence of the above, but this has been a known
behaviour with other types of interface and for the those the advice is
to specify a mac address when you create the interface.

This change will use the `guest_mac` if it's specified for the mac
address on the host if the interface type is macvtap. For macvtap the
mac address on the host is the same as in the guest.

Also removed an erroneous comment about a block of code not being hit.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
