### PR TITLE
chore(test): Add config file option to e2e metal tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ test-with-cov: ## Run unit tests with coverage
 
 .PHONY: test-e2e
 test-e2e: compile-e2e ## Run e2e tests locally
-		go test -timeout 30m -p 1 -v -tags=e2e ./test/e2e/...
+		./test/e2e/test.sh
 
 .PHONY: test-e2e-docker
 test-e2e-docker: compile-e2e ## Run e2e tests locally in a container

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -58,7 +58,7 @@ At the time of writing these are:
 You can pass in these flags to the test like so:
 
 ```bash
-go test -timeout 30m -p 1 -v -tags=e2e ./test/e2e/... -level.flintlockd=9
+./test/e2e/test.sh -level.flintlockd=9
 ```
 
 All the flags can be found at [`params.go`](test/e2e/utils/params.go).

--- a/test/e2e/test.sh
+++ b/test/e2e/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+go test -timeout 30m -p 1 -v -tags=e2e "$(dirname "$(realpath "$0")")"/... "$@"

--- a/test/tools/README.md
+++ b/test/tools/README.md
@@ -49,8 +49,6 @@ This will:
 
 To keep the device around for debugging, add `--skip-delete`.
 
-To not creating anything new and run the tests in an existing device, set `--existing-device-id <id>`.
-
 ## Creating a device
 
 ```bash
@@ -71,3 +69,29 @@ export METAL_AUTH_TOKEN=<your token>
 ```
 
 This will delete the given device. The project will not be deleted.
+
+## Advanced config
+
+The `run-e2e` and `create-device` commands both support receiving params via config
+file.
+
+```bash
+export METAL_AUTH_TOKEN=<your token>
+./test/tools/run.py run-e2e --config-file <path to yaml>
+```
+
+With a config file you can do more, for example:
+
+##### `run-e2e`
+- Run tests in an existing device, without spinning up fresh infra (`device.id`)
+- Configure the device which is created
+- Configure test parameters (`test.flintlockd_log_level`, `test.containerd_log_level`, etc)
+
+##### `create-device`
+- Create a device in an existing project
+- Configure the device which is created
+
+Not all device configuration is exposed yet, but is it fairly trivial to add more when
+required.
+
+To see all available configuration, see the [example config](tests/tools/example-config.yaml).

--- a/test/tools/config.py
+++ b/test/tools/config.py
@@ -1,0 +1,131 @@
+import yamale
+from deepmerge import always_merger
+import random
+import string
+from os.path import dirname, abspath
+
+
+class Config:
+    def __init__(self):
+        self.dir = dirname(abspath(__file__))
+        self.base = dirname(dirname(dirname(abspath(__file__))))
+        self.schema = self.dir + '/schema.yaml'
+        self.params = {}
+        self.set_default_config()
+
+    def __getitem__(self, attr):
+        return self.params[attr]
+
+    def __setitem__(self, key, value):
+        self.params[key] = value
+
+    def set_default_config(self):
+        data = {
+            'org_id': None,
+            'project_id': None,
+            'project_name': self.generated_project_name(),
+            'device': self.default_device_config(),
+            'test': self.default_test_config()
+        }
+        self.params.update(data)
+
+    def set_common(self, org_id=None, key_name=None, dev_name=None):
+        if org_id is not None:
+            self.params['org_id'] = org_id
+        if key_name is not None:
+            self.params['device']['ssh_key_name'] = key_name
+        if dev_name is not None:
+            self.params['device']['name'] = dev_name
+
+    def set_run_flag_config(self, org_id=None, project_name=None, key_name=None, dev_name=None, skip_teardown=None):
+        self.set_common(org_id, key_name, dev_name)
+
+        if project_name is not None:
+            self.params['project_name'] = project_name
+        if skip_teardown is not None:
+            self.params['test']['skip_teardown'] = skip_teardown
+
+    def set_create_flag_config(self, org_id=None, project_id=None, key_name=None, dev_name=None):
+        self.set_common(org_id, key_name, dev_name)
+
+        if project_id is not None:
+            self.params['project_id'] = project_id
+
+    def load_config_from_file(self, config_file):
+        try:
+            schema = yamale.make_schema(self.schema)
+            data = yamale.make_data(config_file)
+            yamale.validate(schema, data)
+        except ValueError as e:
+            raise e
+        self.params = always_merger.merge(self.params, data[0][0])
+
+    def validate_run(self):
+        if self.params['org_id'] is None:
+            raise ValueError("must set org_id")
+
+        if self.params['device']['id'] is not None:
+            self.params['test']['skip_teardown'] = True
+            self.params['device']['name'] = None
+
+        if self.params['test']['skip_delete'] is True:
+            self.params['test']['skip_teardown'] = True
+
+    def validate_create(self):
+        if self.params['org_id'] is None:
+            raise ValueError("must set org_id")
+
+        if self.params['project_id'] is None:
+            raise ValueError("must set project_id")
+
+        try:
+            if self.params['device']['id'] is not None:
+                raise ValueError(
+                    "Error validating config: device.id should not be set")
+        except KeyError:
+            pass
+
+    def default_test_config(self):
+        return {
+            'skip_delete': False,
+            'skip_teardown': False,
+            'skip_dmsetup': False,
+            'containerd_log_level': 'debug',
+            'flintlock_log_level': '2',
+        }
+
+    def default_device_config(self):
+        return {
+            'name': self.default_device_name(),
+            'id': None,
+            'ssh_key_name': self.generated_key_name(),
+            'userdata': self.default_user_data(),
+            'plan': 'c1.small.x86',
+            'operating_system': 'ubuntu_18_04',
+            'metro': 'sv',
+            'facility': 'ewr1',
+            'billing_cycle': 'hourly'
+        }
+
+    def default_user_data(self):
+        files = ["hack/scripts/bootstrap.sh", "test/tools/userdata.sh"]
+        userdata = ""
+        for file in files:
+            with open(self.base + "/" + file) as f:
+                userdata += f.read()
+                userdata += "\n"
+
+        return userdata
+
+    def generate_string(self):
+        letters = string.ascii_letters
+        return (''.join(random.choice(letters) for _ in range(10)))
+
+    def generated_project_name(self):
+        return "flintlock_prj_" + self.generate_string()
+
+    def generated_key_name(self):
+        return "flintlock_key_" + self.generate_string()
+
+    def default_device_name(self):
+        return 'T-800'

--- a/test/tools/example-config.yaml
+++ b/test/tools/example-config.yaml
@@ -1,0 +1,22 @@
+---
+org_id: "test-org" # required
+project_name: "test-project" # or project ID
+project_id: "abcdef123456" # or project ID
+test:
+  skip_delete: false # skip the test cleanup and process teardown steps
+  skip_teardown: false # skip tearing down the equinix infra
+  skip_dmsetup: true # skip the thinpool setup, this should always be true for equinix
+  containerd_log_level: "debug"
+  flintlock_log_level: "2"
+device:
+  name: "test-device" # omit if device.id set
+  id: "abcdef123456" # set if using existing device
+  ssh_key_name: "test-key"
+  # the following mirror the equinix options
+  # see https://metal.equinix.com/developers/docs/ for values
+  userdata: "echo hello"
+  plan: "c1.small.x86"
+  metro: "sv"
+  operating_system: "ubuntu_18_04"
+  facility: "ewr1"
+  billing_cycle: "hourly"

--- a/test/tools/metal.py
+++ b/test/tools/metal.py
@@ -121,20 +121,20 @@ class Welder():
          raise result.to_error()
       self.logger.info("command exited with code %d", result.return_code)
 
-   def delete_all(self, project, device, key):
-      if device != None:
-         device.delete()
-         self.logger.info(f"deleted device {device.hostname}")
+   def delete_all(self):
+      if self.device is not None:
+         self.device.delete()
+         self.logger.info(f"deleted device {self.device.hostname}")
 
-      if key != None:
-         key.delete()
+      if self.key is not None:
+         self.key.delete()
          os.remove(self.private_key_path)
          os.remove(self.public_key_path)
-         self.logger.info(f"deleted key {key.label}")
+         self.logger.info(f"deleted key {self.key.label}")
 
-      if project != None:
-         project.delete()
-         self.logger.info(f"deleted project {project.name}")
+      if self.project is not None:
+         self.project.delete()
+         self.logger.info(f"deleted project {self.project.name}")
 
    def new_shell(self, ip):
       shell = spur.SshShell(

--- a/test/tools/metal.py
+++ b/test/tools/metal.py
@@ -117,6 +117,8 @@ class Welder():
       shell = self.new_shell(self.ip)
       with shell:
          result = shell.run(command=cmd, cwd=cwd, stdout=sys.stdout.buffer, stderr=sys.stderr.buffer, allow_error=allow_error)
+      if result.return_code != 0:
+         raise result.to_error()
       self.logger.info("command exited with code %d", result.return_code)
 
    def delete_all(self, project, device, key):

--- a/test/tools/metal.py
+++ b/test/tools/metal.py
@@ -7,157 +7,172 @@ import sys
 from Crypto.PublicKey import RSA
 from os.path import dirname, abspath
 
+
 class Welder():
-   def __init__(self, auth_token, config, level=logging.INFO):
-      self.config = config
-      self.org_id = config['org_id']
-      self.packet_manager = packet.Manager(auth_token=auth_token)
-      self.private_key_path = dirname(abspath(__file__))+"/private.key"
-      self.public_key_path = dirname(abspath(__file__))+"/public.key"
-      self.logger = self.set_logger(level)
-      self.ip = None
+    def __init__(self, auth_token, config, level=logging.INFO):
+        self.config = config
+        self.org_id = config['org_id']
+        self.packet_manager = packet.Manager(auth_token=auth_token)
+        self.private_key_path = dirname(abspath(__file__)) + "/private.key"
+        self.public_key_path = dirname(abspath(__file__)) + "/public.key"
+        self.logger = self.set_logger(level)
+        self.ip = None
 
-   def set_logger(self, level):
-      logger = logging.getLogger('welder')
-      logger.setLevel(level)
-      c_handler = logging.StreamHandler()
-      c_handler.setLevel(level)
-      c_format = logging.Formatter('%(asctime)s %(levelname)s %(name)s - %(message)s', "%Y-%m-%d.%H:%M:%S")
-      c_handler.setFormatter(c_format)
-      logger.addHandler(c_handler)
+    def set_logger(self, level):
+        logger = logging.getLogger('welder')
+        logger.setLevel(level)
+        c_handler = logging.StreamHandler()
+        c_handler.setLevel(level)
+        c_format = logging.Formatter(
+            '%(asctime)s %(levelname)s %(name)s - %(message)s',
+            "%Y-%m-%d.%H:%M:%S")
+        c_handler.setFormatter(c_format)
+        logger.addHandler(c_handler)
 
-      return logger
+        return logger
 
-   def create_all(self):
-      project = self.create_new_project_if_not_exist()
-      self.project = project
-      key = self.create_new_key(project.id, self.config['device']['ssh_key_name'])
-      self.key = key
-      device = self.create_device(project.id, key.id)
-      self.device = device
-      self.dev_id = device.id
-      self.wait_until_device_ready(device)
+    def create_all(self):
+        project = self.create_new_project_if_not_exist()
+        self.project = project
+        key = self.create_new_key(
+            project.id, self.config['device']['ssh_key_name'])
+        self.key = key
+        device = self.create_device(project.id, key.id)
+        self.device = device
+        self.dev_id = device.id
+        self.wait_until_device_ready(device)
 
-      return self.ip
+        return self.ip
 
-   def create_new_project_if_not_exist(self):
-      project = None
-      try:
-         project = self.packet_manager.get_project(self.config['project_id'])
-         self.logger.info(f"using found project {self.config['project_id']}")
-         return project
-      except Exception:
-         self.logger.info(f"could not find project {self.config['project_id']}")
-         pass
+    def create_new_project_if_not_exist(self):
+        project = None
+        try:
+            project = self.packet_manager.get_project(
+                self.config['project_id'])
+            self.logger.info(
+                f"using found project {self.config['project_id']}")
+            return project
+        except Exception:
+            self.logger.info(
+                f"could not find project {self.config['project_id']}")
+            pass
 
-      project = self.packet_manager.create_organization_project(
-          org_id=self.org_id,
-          name=self.config['project_name']
-      )
-      self.logger.info(f"created project {project.name}")
+        project = self.packet_manager.create_organization_project(
+            org_id=self.org_id,
+            name=self.config['project_name']
+        )
+        self.logger.info(f"created project {project.name}")
 
-      return project
+        return project
 
-   def create_new_key(self, project_id, name):
-      key = RSA.generate(2048)
-      with open(self.private_key_path, 'wb') as priv_file:
-          os.chmod(self.private_key_path, 0o600)
-          priv_file.write(key.exportKey('PEM'))
+    def create_new_key(self, project_id, name):
+        key = RSA.generate(2048)
+        with open(self.private_key_path, 'wb') as priv_file:
+            os.chmod(self.private_key_path, 0o600)
+            priv_file.write(key.exportKey('PEM'))
 
-      pubkey = key.publickey().exportKey('OpenSSH')
-      with open(self.public_key_path, 'wb') as pub_file:
-          pub_file.write(pubkey)
+        pubkey = key.publickey().exportKey('OpenSSH')
+        with open(self.public_key_path, 'wb') as pub_file:
+            pub_file.write(pubkey)
 
-      key = self.packet_manager.create_project_ssh_key(project_id, name, pubkey.decode("utf-8"))
-      self.logger.info(f"created key {key.label}")
+        key = self.packet_manager.create_project_ssh_key(
+            project_id, name, pubkey.decode("utf-8"))
+        self.logger.info(f"created key {key.label}")
 
-      return key
+        return key
 
-   def create_device(self, project_id, key_id):
-      cfg = self.config['device']
-      device = self.packet_manager.create_device(project_id=project_id,
-                                     hostname=cfg['name'],
-                                     plan=cfg['plan'], metro=cfg['metro'],
-                                     operating_system=cfg['operating_system'],
-                                     facility=cfg['facility'], billing_cycle=cfg['billing_cycle'],
-                                     project_ssh_keys=[key_id],
-                                     userdata=cfg['userdata'])
-      self.logger.info(f"created device {device.hostname}")
+    def create_device(self, project_id, key_id):
+        cfg = self.config['device']
+        device = self.packet_manager.create_device(project_id=project_id,
+                                                   hostname=cfg['name'],
+                                                   plan=cfg['plan'], metro=cfg['metro'],
+                                                   operating_system=cfg['operating_system'],
+                                                   facility=cfg['facility'], billing_cycle=cfg['billing_cycle'],
+                                                   project_ssh_keys=[key_id],
+                                                   userdata=cfg['userdata'])
+        self.logger.info(f"created device {device.hostname}")
 
-      return device
+        return device
 
-   # TODO timeouts
-   def wait_until_device_ready(self, device):
-      while True:
-         d = self.packet_manager.get_device(device_id=device.id)
-         self.logger.info(f"checking state of device {d.hostname} ...")
-         if d.state == "active":
-             self.logger.info(f"{d.hostname} running")
-             break
-         self.logger.info(f"state '{d.state}' != 'active', sleeping for 10s")
-         time.sleep(10)
+    # TODO timeouts
+    def wait_until_device_ready(self, device):
+        while True:
+            d = self.packet_manager.get_device(device_id=device.id)
+            self.logger.info(f"checking state of device {d.hostname} ...")
+            if d.state == "active":
+                self.logger.info(f"{d.hostname} running")
+                break
+            self.logger.info(
+                f"state '{d.state}' != 'active', sleeping for 10s")
+            time.sleep(10)
 
-      ips = device.ips()
-      self.ip = ips[0].address
+        ips = device.ips()
+        self.ip = ips[0].address
 
-      while True:
-         shell = self.new_shell(self.ip)
-         self.logger.info("checking userdata has completed...")
-         with shell:
-            result = shell.run(["ls", "/flintlock_ready"], allow_error=True)
-         if result.return_code == 0:
-            self.logger.info("userdata ran successfully")
-            break
-         self.logger.info("userdata still running, sleeping for 10s")
-         time.sleep(10)
+        while True:
+            shell = self.new_shell(self.ip)
+            self.logger.info("checking userdata has completed...")
+            with shell:
+                result = shell.run(
+                    ["ls", "/flintlock_ready"], allow_error=True)
+            if result.return_code == 0:
+                self.logger.info("userdata ran successfully")
+                break
+            self.logger.info("userdata still running, sleeping for 10s")
+            time.sleep(10)
 
-      self.logger.info(f"device {device.hostname} (id: {device.id}) ready")
+        self.logger.info(f"device {device.hostname} (id: {device.id}) ready")
 
-   def run_ssh_command(self, cmd, cwd, allow_error=True):
-      shell = self.new_shell(self.ip)
-      with shell:
-         result = shell.run(command=cmd, cwd=cwd, stdout=sys.stdout.buffer, stderr=sys.stderr.buffer, allow_error=allow_error)
-      if result.return_code != 0:
-         raise result.to_error()
-      self.logger.info("command exited with code %d", result.return_code)
+    def run_ssh_command(self, cmd, cwd, allow_error=True):
+        shell = self.new_shell(self.ip)
+        with shell:
+            result = shell.run(
+                command=cmd,
+                cwd=cwd,
+                stdout=sys.stdout.buffer,
+                stderr=sys.stderr.buffer,
+                allow_error=allow_error)
+        if result.return_code != 0:
+            raise result.to_error()
+        self.logger.info("command exited with code %d", result.return_code)
 
-   def delete_all(self):
-      if self.device is not None:
-         self.device.delete()
-         self.logger.info(f"deleted device {self.device.hostname}")
+    def delete_all(self):
+        if self.device is not None:
+            self.device.delete()
+            self.logger.info(f"deleted device {self.device.hostname}")
 
-      if self.key is not None:
-         self.key.delete()
-         os.remove(self.private_key_path)
-         os.remove(self.public_key_path)
-         self.logger.info(f"deleted key {self.key.label}")
+        if self.key is not None:
+            self.key.delete()
+            os.remove(self.private_key_path)
+            os.remove(self.public_key_path)
+            self.logger.info(f"deleted key {self.key.label}")
 
-      if self.project is not None:
-         self.project.delete()
-         self.logger.info(f"deleted project {self.project.name}")
+        if self.project is not None:
+            self.project.delete()
+            self.logger.info(f"deleted project {self.project.name}")
 
-   def new_shell(self, ip):
-      shell = spur.SshShell(
-         hostname=ip,
-         username="root",
-         load_system_host_keys=False,
-         missing_host_key=spur.ssh.MissingHostKey.accept,
-         private_key_file=self.private_key_path
-      )
+    def new_shell(self, ip):
+        shell = spur.SshShell(
+            hostname=ip,
+            username="root",
+            load_system_host_keys=False,
+            missing_host_key=spur.ssh.MissingHostKey.accept,
+            private_key_file=self.private_key_path
+        )
 
-      return shell
+        return shell
 
-   def get_device(self, device_id):
-      return self.packet_manager.get_device(device_id=device_id)
+    def get_device(self, device_id):
+        return self.packet_manager.get_device(device_id=device_id)
 
-   def get_device_ip(self, device_id):
-      d = self.get_device(device_id)
-      ips = d.ips()
-      self.ip = ips[0].address
+    def get_device_ip(self, device_id):
+        d = self.get_device(device_id)
+        ips = d.ips()
+        self.ip = ips[0].address
 
-      return self.ip
+        return self.ip
 
-   def delete_device(self, device_id):
-      device = self.get_device(device_id)
-      device.delete()
-      self.logger.info(f"deleted device {device.hostname}")
+    def delete_device(self, device_id):
+        device = self.get_device(device_id)
+        device.delete()
+        self.logger.info(f"deleted device {device.hostname}")

--- a/test/tools/requirements.txt
+++ b/test/tools/requirements.txt
@@ -2,3 +2,6 @@ click==7.1.2
 packet-python==1.44.1
 pycryptodome==3.11.0
 spur==0.3.22
+yamale==4.0.2
+autopep8==1.6.0
+deepmerge==0.3.0

--- a/test/tools/run.py
+++ b/test/tools/run.py
@@ -10,12 +10,14 @@ import random
 import string
 from os.path import dirname, abspath
 
+
 @click.group()
 def cli():
     """
     General thing doer for flintlock
     """
     pass
+
 
 @cli.command()
 @click.option('-c', '--config-file', type=str, help='Path to configuration file')
@@ -38,7 +40,8 @@ def run_e2e(config_file, org_id, project_name, ssh_key_name, device_name, skip_t
             click.echo(str(e))
             sys.exit()
 
-    cfg.set_run_flag_config(org_id, project_name, ssh_key_name, device_name, skip_teardown)
+    cfg.set_run_flag_config(org_id, project_name,
+                            ssh_key_name, device_name, skip_teardown)
     try:
         cfg.validate_run()
     except ValueError as e:
@@ -46,12 +49,15 @@ def run_e2e(config_file, org_id, project_name, ssh_key_name, device_name, skip_t
         sys.exit()
 
     if cfg['device']['id'] == None:
-        click.echo(f"Running e2e tests. Will create project `{cfg['project_name']}`, ssh_key `{cfg['device']['ssh_key_name']}` and device `{cfg['device']['name']}`")
-        click.echo("Note: this will create and bootstrap a new device in Equinix and may take some time")
+        click.echo(
+            f"Running e2e tests. Will create project `{cfg['project_name']}`, ssh_key `{cfg['device']['ssh_key_name']}` and device `{cfg['device']['name']}`")
+        click.echo(
+            "Note: this will create and bootstrap a new device in Equinix and may take some time")
     else:
         tool_dir = dirname(abspath(__file__))
         if os.path.exists(tool_dir+"/private.key") != True:
-            click.echo(f"`private.key` file must be saved at `{tool_dir}` when `--existing-device-id` flag set")
+            click.echo(
+                f"`private.key` file must be saved at `{tool_dir}` when `--existing-device-id` flag set")
             sys.exit()
         click.echo("running e2e tests using device `{cfg['device']['id']}`")
 
@@ -63,6 +69,7 @@ def run_e2e(config_file, org_id, project_name, ssh_key_name, device_name, skip_t
     if cfg['test']['skip_teardown']:
         dev_id, dev_ip = runner.device_details()
         click.echo(f"Device `{dev_id}` left alive for debugging. Use with `--config-file` setting `device.id` to re-run tests. SSH command `ssh -i test/tools/private.key root@{dev_ip}`. Teardown device with `teardown-device` command.")
+
 
 @cli.command()
 @click.option('-c', '--config-file', type=str, help='Path to configuration file')
@@ -92,12 +99,15 @@ def create_device(config_file, org_id, project_id, ssh_key_name, device_name, us
         click.echo(str(e))
         sys.exit()
 
-    click.echo(f"Creating device {cfg['device']['name']} with config {cfg['device']}")
+    click.echo(
+        f"Creating device {cfg['device']['name']} with config {cfg['device']}")
 
     welder = Welder(token, cfg)
     ip = welder.create_all()
 
-    click.echo(f"Device {cfg['device']['name']} created. SSH command `ssh -i test/tools/private.key root@{ip}`. Run tests with `run-e2e`. Teardown with `delete-device`.")
+    click.echo(
+        f"Device {cfg['device']['name']} created. SSH command `ssh -i test/tools/private.key root@{ip}`. Run tests with `run-e2e`. Teardown with `delete-device`.")
+
 
 @cli.command()
 @click.option('-o', '--org-id', type=str, help='Equinix organisation id (required)')
@@ -118,6 +128,7 @@ def delete_device(org_id, device_id):
 
     welder = Welder(token, org_id)
     welder.delete_device(device_id)
+
 
 if __name__ == "__main__":
     cli()

--- a/test/tools/run.py
+++ b/test/tools/run.py
@@ -2,22 +2,13 @@
 
 from test import Test
 from metal import Welder
+from config import Config
 import click
 import os
 import sys
 import random
 import string
 from os.path import dirname, abspath
-
-def generate_string():
-    letters = string.ascii_letters
-    return ( ''.join(random.choice(letters) for i in range(10)) )
-
-def generated_project_name():
-    return "flintlock_prj_"+generate_string()
-
-def generated_key_name():
-    return "flintlock_key_"+generate_string()
 
 @click.group()
 def cli():
@@ -27,40 +18,51 @@ def cli():
     pass
 
 @cli.command()
+@click.option('-c', '--config-file', type=str, help='Path to configuration file')
 @click.option('-o', '--org-id', type=str, help='Equinix organisation id (required)')
-@click.option('-p', '--project-name', type=str, help='Name of the project to create (default: randomly generated)', default=generated_project_name())
-@click.option('-k', '--ssh-key-name', type=str, help='Name of the ssh key to create and attach to the device (default: randomly generated)', default=generated_key_name())
-@click.option('-d', '--device-name', type=str, help='Name of the device to create (default: randomly generated)', default='T-800')
-@click.option('-e', '--existing-device-id', type=str, help='Skip create and set the UUID of an existing device to run tests against', default=None)
-@click.option('-s', '--skip-delete', is_flag=True, help='Skip cleanup of Equinix infrastructure for debugging after run', default=False)
-def run_e2e(org_id, project_name, ssh_key_name, device_name, skip_delete, existing_device_id):
+@click.option('-p', '--project-name', type=str, help='Name of the project to create (default: randomly generated)')
+@click.option('-k', '--ssh-key-name', type=str, help='Name of the ssh key to create and attach to the device (default: randomly generated)')
+@click.option('-d', '--device-name', type=str, help='Name of the device to create (default: randomly generated)')
+@click.option('-s', '--skip-teardown', is_flag=True, help='Skip cleanup of Equinix infrastructure for debugging after run')
+def run_e2e(config_file, org_id, project_name, ssh_key_name, device_name, skip_teardown):
     token = os.environ.get("METAL_AUTH_TOKEN")
     if token is None:
         click.echo("must set METAL_AUTH_TOKEN")
         sys.exit()
-    if org_id is None:
-        click.echo("must set --org-id")
+
+    cfg = Config()
+    if config_file is not None:
+        try:
+            cfg.load_config_from_file(config_file)
+        except ValueError as e:
+            click.echo(str(e))
+            sys.exit()
+
+    cfg.set_run_flag_config(org_id, project_name, ssh_key_name, device_name, skip_teardown)
+    try:
+        cfg.validate_run()
+    except ValueError as e:
+        click.echo(str(e))
         sys.exit()
 
-    if existing_device_id == None:
-        click.echo(f"Running e2e tests. Will create project '{project_name}', ssh_key '{ssh_key_name}' and device '{device_name}'")
+    if cfg['device']['id'] == None:
+        click.echo(f"Running e2e tests. Will create project `{cfg['project_name']}`, ssh_key `{cfg['device']['ssh_key_name']}` and device `{cfg['device']['name']}`")
         click.echo("Note: this will create and bootstrap a new device in Equinix and may take some time")
     else:
-        skip_delete = True
         tool_dir = dirname(abspath(__file__))
         if os.path.exists(tool_dir+"/private.key") != True:
             click.echo(f"`private.key` file must be saved at `{tool_dir}` when `--existing-device-id` flag set")
             sys.exit()
-        click.echo("running e2e tests using device '{existing_device_id}`")
+        click.echo("running e2e tests using device `{cfg['device']['id']}`")
 
-    runner = Test(token, org_id, project_name, ssh_key_name, device_name, skip_delete, existing_device_id)
+    runner = Test(token, cfg)
     with runner:
         runner.setup()
         runner.run_tests()
 
-    if skip_delete:
+    if cfg['test']['skip_teardown']:
         dev_id, dev_ip = runner.device_details()
-        click.echo(f"Device `{dev_id}` left alive for debugging. Use with `--existing-device-id` to re-run tests. SSH command `ssh -i hack/tools/private.key root@{dev_ip}`. Delete device with `delete-device` command.")
+        click.echo(f"Device `{dev_id}` left alive for debugging. Use with `--config-file` setting `device.id` to re-run tests. SSH command `ssh -i test/tools/private.key root@{dev_ip}`. Teardown device with `teardown-device` command.")
 
 @cli.command()
 @click.option('-o', '--org-id', type=str, help='Equinix organisation id (required)')

--- a/test/tools/schema.yaml
+++ b/test/tools/schema.yaml
@@ -1,0 +1,22 @@
+org_id: str(required=True)
+project_name: str(required=False)
+project_id: str(required=False)
+test: include('test', required=False)
+device: include('device', required=False)
+---
+test:
+  skip_delete: bool(required=False)
+  skip_teardown: bool(required=False)
+  skip_dmsetup: bool(required=False)
+  containerd_log_level: str(required=False)
+  flintlock_log_level: str(required=False)
+device:
+  name: str(required=False)
+  id: str(required=False)
+  ssh_key_name: str(required=False)
+  userdata: str(required=False)
+  plan: str(required=False)
+  metro: str(required=False)
+  operating_system: str(required=False)
+  facility: str(required=False)
+  billing_cycle: str(required=False)

--- a/test/tools/test.py
+++ b/test/tools/test.py
@@ -1,13 +1,16 @@
 from metal import Welder
 
 class Test:
-    def __init__(self, auth_token, org_id, prj_name, key_name, dev_name, skip_delete, dev_id=None):
-        self.welder = Welder(auth_token, org_id)
-        self.prj_name = prj_name
-        self.key_name = key_name
-        self.dev_name = dev_name
-        self.skip_delete = skip_delete
-        self.dev_id = dev_id
+    def __init__(self, auth_token, config):
+        self.testCfg = config['test']
+        devCfg = config['device']
+
+        self.welder = Welder(auth_token, config)
+        self.prj_name = config['project']
+        self.key_name = devCfg['ssh_key_name']
+        self.dev_name = devCfg['name']
+        self.skip_teardown = self.testCfg['skip_teardown']
+        self.dev_id = devCfg['id']
         self.dev_ip = None
         self.project = None
         self.key = None
@@ -17,7 +20,7 @@ class Test:
         return self
 
     def __exit__(self, *args, **kwargs):
-        if self.skip_delete == False:
+        if self.skip_teardown == False:
             self.teardown()
 
     def setup(self):

--- a/test/tools/test.py
+++ b/test/tools/test.py
@@ -37,7 +37,7 @@ class Test:
         self.welder.delete_all(self.project, self.device, self.key)
 
     def create_infra(self):
-        self.dev_ip = self.welder.create_all(self.prj_name, self.dev_name, self.key_name)
+        self.dev_ip = self.welder.create_all()
 
     def fetch_infra(self):
         try:

--- a/test/tools/test.py
+++ b/test/tools/test.py
@@ -13,19 +13,15 @@ class Test:
         self.skip_teardown = self.testCfg['skip_teardown']
         self.dev_id = devCfg['id']
         self.dev_ip = None
-        self.project = None
-        self.key = None
-        self.device = None
 
     def __enter__(self):
         return self
 
     def __exit__(self, *args, **kwargs):
-        if self.skip_teardown == False:
-            self.teardown()
+        self.teardown()
 
     def setup(self):
-        if self.dev_id != None:
+        if self.dev_id is not None:
             self.fetch_infra()
         else:
             self.create_infra()
@@ -47,7 +43,9 @@ class Test:
             pass
 
     def teardown(self):
-        self.welder.delete_all(self.project, self.device, self.key)
+        if self.skip_teardown:
+            return
+        self.welder.delete_all()
 
     def create_infra(self):
         self.dev_ip = self.welder.create_all()

--- a/test/tools/test.py
+++ b/test/tools/test.py
@@ -40,7 +40,11 @@ class Test:
             cmd.append('-skip.delete')
         if self.testCfg['skip_dmsetup']:
             cmd.append('-skip.setup.thinpool')
-        self.welder.run_ssh_command(cmd, "/root/work/flintlock", False)
+        try:
+            self.welder.run_ssh_command(cmd, "/root/work/flintlock", False)
+        except RuntimeError as e:
+            print(str(e))
+            pass
 
     def teardown(self):
         self.welder.delete_all(self.project, self.device, self.key)

--- a/test/tools/test.py
+++ b/test/tools/test.py
@@ -1,5 +1,6 @@
 from metal import Welder
 
+
 class Test:
     def __init__(self, auth_token, config):
         self.testCfg = config['test']
@@ -30,7 +31,15 @@ class Test:
             self.create_infra()
 
     def run_tests(self):
-        cmd = ['make', 'test-e2e']
+        cmd = ['./test/e2e/test.sh',
+               '-level.flintlockd', self.testCfg['flintlock_log_level'],
+               '-level.containerd', self.testCfg['containerd_log_level'],
+               ]
+        if self.testCfg['skip_delete']:
+            cmd.append('-skip.teardown')
+            cmd.append('-skip.delete')
+        if self.testCfg['skip_dmsetup']:
+            cmd.append('-skip.setup.thinpool')
         self.welder.run_ssh_command(cmd, "/root/work/flintlock", False)
 
     def teardown(self):


### PR DESCRIPTION
**Note: the last 2 commits are file formatting only and disguise other things which have happened**

**What this PR does / why we need it**:

This PR adds a bit of nice UX to the e2e python tool.

Users can now pass a config file:

```
./test/tools/run.py -c <path to file>
```

Which looks like this:

```yaml
---
org_id: "test-org" # required
project: "test-project" # or project ID
test:
  skip_delete: false # skip the test cleanup and process teardown steps
  skip_teardown: false # skip tearing down the equinix infra
  skip_dmsetup: true # skip the thinpool setup, this should always be true for equinix
  containerd_log_level: "debug"
  flintlock_log_level: "2"
device:
  name: "test-device" # omit if device.id set
  id: "abcdef123456" # set if using existing device
  ssh_key_name: "test-key"
  # the following mirror the equinix options
  # see https://metal.equinix.com/developers/docs/ for values
  userdata: "echo hello"
  plan: "c1.small.x86"
  metro: "sv"
  operating_system: "ubuntu_18_04"
  facility: "ewr1"
  billing_cycle: "hourly"
```

Each new instance of Config will be initialised with a set of default
config. These are just the values I happened to be hardcoding before,
and there was no special reason for any of them, but they work.

Config can then be loaded from a file and validated against a schema.
This config will then overwrite the appropriate values in the object
config.

Config can also be altered via flags. The 'final' config at that point
can be validated.

The validation is all a bit naive right now as I didn't want to get too
into it.

Not all device config options exist yet, but it is fairly trivial to add as
needed later.

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [x] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
