### PR TITLE
feat: Add script to setup direct-lvm mode for containerd

### DIFF
--- a/hack/scripts/devpool.sh
+++ b/hack/scripts/devpool.sh
@@ -23,8 +23,8 @@ fi
 set -u
 # These are some useful vars for useful things
 DIR="${CROOT}/snapshotter/devmapper"
-META="${CROOT}/snapshotter/devmapper/metadata$VOL_TAG"
-DATA="${CROOT}/snapshotter/devmapper/data$VOL_TAG"
+META="${DIR}/metadata$VOL_TAG"
+DATA="${DIR}/data$VOL_TAG"
 
 mkdir -p "${DIR}"
 

--- a/hack/scripts/direct_lvm.sh
+++ b/hack/scripts/direct_lvm.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+# WARNING: THIS SCRIPT HAS MUTLIPLE PURPOSES.
+# TAKE CARE WHEN EDITING.
+
+# This is a scripted version of https://docs.docker.com/storage/storagedriver/device-mapper-driver/#configure-direct-lvm-mode-manually
+
+set -ex
+
+if [[ $(id -u) != 0 ]]; then
+  echo "Run this script as root..." >&2
+  exit 1
+fi
+
+DISK_NAME="$THINPOOL_DISK_NAME"
+POOL_NAME_PREFIX="flintlock"
+
+usage() {
+cat << EOF
+usage: $0 -d DISK_NAME [-p POOL_NAME]
+
+Script to generate release data for eksctl and profiles projects.
+
+OPTIONS:
+   -d YEAR	  (Required if \$THINPOOL_DISK_NAME not set) Set the name of the disk to use for thinpool storage
+   -p POOL_NAME	  Name of the thinpool to create (default: flintlock)
+   -h		  Show this message
+EOF
+}
+
+while getopts ":hd:p:" OPTION
+do
+  case $OPTION in
+    h)
+      usage
+      exit
+      ;;
+    d)
+      DISK_NAME=$OPTARG
+      ;;
+    p)
+      POOL_NAME_PREFIX=$OPTARG
+      ;;
+    ?)
+      usage
+      exit
+      ;;
+  esac
+done
+
+if [[ -z "$DISK_NAME" ]]; then
+  echo "one of \$THINPOOL_DISK_NAME or '-d NAME' must be set"
+  exit 1
+fi
+
+DISK_PATH="/dev/$DISK_NAME"
+PROFILE="/etc/lvm/profile/$POOL_NAME_PREFIX-thinpool.profile"
+CROOT=/var/lib/containerd-flintlock
+DIR="${CROOT}/snapshotter/devmapper"
+
+echo "will create thinpool $POOL_NAME_PREFIX-thinpool on $DISK_PATH"
+
+apt update
+apt install -y thin-provisioning-tools lvm2
+
+if [[ $(pvdisplay) != *"$DISK_PATH"* ]]; then
+  pvcreate "$DISK_PATH"
+  echo "created physical volume on $DISK_PATH"
+fi
+
+if [[ $(vgdisplay) != *"$POOL_NAME_PREFIX"* ]]; then
+  vgcreate "$POOL_NAME_PREFIX" "$DISK_PATH"
+  echo "created volume group on $DISK_PATH"
+fi
+
+if [[ $(lvdisplay) != *"$POOL_NAME_PREFIX"* ]]; then
+  lvcreate --wipesignatures y -n thinpool "$POOL_NAME_PREFIX" -l 95%VG
+  echo "created logical volume for $POOL_NAME_PREFIX data"
+
+  lvcreate --wipesignatures y -n thinpoolmeta "$POOL_NAME_PREFIX" -l 1%VG
+  echo "created logical volume for $POOL_NAME_PREFIX metadata"
+
+  lvconvert -y \
+    --zero n \
+    -c 512K \
+    --thinpool "$POOL_NAME_PREFIX"/thinpool \
+    --poolmetadata "$POOL_NAME_PREFIX"/thinpoolmeta
+  echo "converted logical volumes to thinpool storage"
+fi
+
+
+if [[ ! -f "$PROFILE" ]]; then
+cat <<'EOF' >> "$PROFILE"
+activation {
+  thin_pool_autoextend_threshold=80
+  thin_pool_autoextend_percent=20
+}
+EOF
+echo "written lvm profile to $PROFILE"
+fi
+
+if [[ $(lvs) != *"$POOL_NAME_PREFIX"* ]]; then
+  lvchange --metadataprofile "$POOL_NAME_PREFIX-thinpool" "$POOL_NAME_PREFIX"/thinpool
+  echo "applied lvm profile for $POOL_NAME_PREFIX-thinpool"
+fi
+
+try=1
+max=5
+while [ "$try" -le "$max" ]; do
+  echo "checking that lvm profile for $POOL_NAME_PREFIX-thinpool is monitored"
+  if [[ $(lvs -o+seg_monitor) == *"not monitored"* ]]; then
+    lvchange --monitor y "$POOL_NAME_PREFIX"/thinpool
+    ((try=try+1))
+
+    if [[ "$try" -gt "$max" ]]; then
+      echo "could not monitor lvm profile"
+      exit 1
+    fi
+
+    continue
+  fi
+
+  break
+done
+
+echo "successfully monitored $POOL_NAME_PREFIX-thinpool profile"
+echo "thinpool $POOL_NAME_PREFIX-thinpool is ready for use"
+
+cat << EOF
+#
+# Add this to your config.toml configuration file and restart containerd daemon
+#
+[plugins]
+  [plugins.devmapper]
+    pool_name = "${POOL_NAME_PREFIX}-thinpool"
+    root_path = "${DIR}"
+    base_image_size = "10GB"
+    discard_blocks = true
+EOF

--- a/test/tools/config/config.py
+++ b/test/tools/config/config.py
@@ -100,16 +100,16 @@ class Config:
             'id': None,
             'ssh_key_name': self.generated_key_name(),
             'userdata': self.default_user_data(),
-            'plan': 'c1.small.x86',
+            'plan': 'c3.small.x86',
             'operating_system': 'ubuntu_18_04',
             'metro': 'sv',
-            'facility': 'ewr1',
+            'facility': 'am6',
             'billing_cycle': 'hourly'
         }
 
     def default_user_data(self):
-        files = ["hack/scripts/bootstrap.sh", "test/tools/config/userdata.sh"]
-        userdata = ""
+        files = ["hack/scripts/bootstrap.sh", "hack/scripts/direct_lvm.sh", "test/tools/config/userdata.sh"]
+        userdata = "#!/bin/bash\n export THINPOOL_DISK_NAME=sdb\n"
         for file in files:
             with open(self.base + "/" + file) as f:
                 userdata += f.read()


### PR DESCRIPTION
**What this PR does / why we need it**:

Using loop devices for devmapper's thinpool is not recommended for
production.

Real block devices are required to back thinpools in production.

This PR:
- adds an alternative script which users can run if they want a
  production-ready setup. The script will take a given free device and
  create the required physical and logical volumes, formatting them into
  thinpool storage.
- this device can also be provided via an environment variable, which
makes it easier to use the script in the tooling userdata
- updates the quickstart docs to include the option.
- adds the script to the equinix tooling userdata so that equinix vms
  are bootstrapped with direct-lvm by default.
- changes the default machine created by the tooling so that a type
  with a spare disk which is not mounted or partitioned is available. This
  saves us having to sort out extra storage which is a right pain now that
  Equinix has deprecated their native storage offering.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/weaveworks/flintlock/issues/146

**Special notes for your reviewer**:
There is more wiring with the tests coming soon, just separating out the PRs

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
