### PR TITLE
feat(test): Wire e2e tests to use direct lvm thinpool for containerd

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -48,7 +48,8 @@ There are a couple of custom test flags which you can set to alter the behaviour
 of the tests.
 
 At the time of writing these are:
-- `skip.setup.thinpool`: skips the setup of devicemapper thinpools.
+- `skip.setup.thinpool`: skips the setup of devicemapper thinpool.
+- `thinpool`: set the name of a custom thinpool to create and/or use instead.
 - `skip.delete`: skip the Delete step of the tests and leave the mVMs around for debugging.
   This will also leave containerd and flintlockd running. All cleanup will be manual.
 - `skip.teardown`: skip stopping containerd and flintlockd processes.

--- a/test/e2e/utils/params.go
+++ b/test/e2e/utils/params.go
@@ -5,6 +5,10 @@ package utils
 
 import "flag"
 
+const (
+	thinpoolName = "dev-thinpool-e2e"
+)
+
 // Params groups all param.
 type Params struct {
 	SkipSetupThinpool  bool
@@ -12,13 +16,15 @@ type Params struct {
 	SkipDelete         bool
 	ContainerdLogLevel string
 	FlintlockdLogLevel string
+	ThinpoolName       string
 }
 
 // NewParams returns a new Params based on provided flags.
 func NewParams() *Params {
 	params := Params{}
 
-	flag.BoolVar(&params.SkipSetupThinpool, "skip.setup.thinpool", false, "Skip setting up devicemapper thinpools")
+	flag.BoolVar(&params.SkipSetupThinpool, "skip.setup.thinpool", false, "Skip setting up loop-backed devicemapper thinpools. Assumes existing direct-lvm setup. Must be used with -thinpool")
+	flag.StringVar(&params.ThinpoolName, "thinpool", thinpoolName, "Name of thinpool to create or of existing thinpool. When existing skip.setup.thinpool should also be set")
 	flag.BoolVar(&params.SkipDelete, "skip.delete", false, "Skip running the 'delete vm' step of the tests (useful for debugging, this will also leave containerd and flintlockd running)")
 	flag.BoolVar(&params.SkipTeardown, "skip.teardown", false, "Do not stop containerd or flintlockd after test exit (note: will require manual cleanup)")
 	flag.StringVar(&params.ContainerdLogLevel, "level.containerd", "debug", "Set containerd's log level [trace, *debug*, info, warn, error, fatal, panic]")

--- a/test/tools/config/config.py
+++ b/test/tools/config/config.py
@@ -24,21 +24,13 @@ class Config:
             'org_id': None,
             'project_id': None,
             'project_name': self.generated_project_name(),
-            'device': self.default_device_config(),
-            'test': self.default_test_config()
+            'device': self.initial_device_config(),
+            'test': self.initial_test_config()
         }
         self.params.update(data)
 
-    def set_common(self, org_id=None, key_name=None, dev_name=None):
-        if org_id is not None:
-            self.params['org_id'] = org_id
-        if key_name is not None:
-            self.params['device']['ssh_key_name'] = key_name
-        if dev_name is not None:
-            self.params['device']['name'] = dev_name
-
     def set_run_flag_config(self, org_id=None, project_name=None, key_name=None, dev_name=None, skip_teardown=None):
-        self.set_common(org_id, key_name, dev_name)
+        self.set_common_flags(org_id, key_name, dev_name)
 
         if project_name is not None:
             self.params['project_name'] = project_name
@@ -46,10 +38,18 @@ class Config:
             self.params['test']['skip_teardown'] = skip_teardown
 
     def set_create_flag_config(self, org_id=None, project_id=None, key_name=None, dev_name=None):
-        self.set_common(org_id, key_name, dev_name)
+        self.set_common_flags(org_id, key_name, dev_name)
 
         if project_id is not None:
             self.params['project_id'] = project_id
+
+    def set_common_flags(self, org_id=None, key_name=None, dev_name=None):
+        if org_id is not None:
+            self.params['org_id'] = org_id
+        if key_name is not None:
+            self.params['device']['ssh_key_name'] = key_name
+        if dev_name is not None:
+            self.params['device']['name'] = dev_name
 
     def load_config_from_file(self, config_file):
         try:
@@ -64,14 +64,12 @@ class Config:
         if self.params['org_id'] is None:
             raise ValueError("must set org_id")
 
-        if self.params['device']['id'] is not None:
-            self.params['test']['skip_teardown'] = True
-            self.params['device']['name'] = None
-
-        if self.params['test']['skip_delete'] is True:
-            self.params['test']['skip_teardown'] = True
+        self.configure_test()
+        self.configure_device()
 
     def validate_create(self):
+        self.configure_device()
+
         if self.params['org_id'] is None:
             raise ValueError("must set org_id")
 
@@ -85,21 +83,33 @@ class Config:
         except KeyError:
             pass
 
-    def default_test_config(self):
+    def configure_test(self):
+        if self.params['device']['id'] is not None:
+            self.params['test']['skip_teardown'] = True
+            self.params['device']['name'] = None
+
+        if self.params['test']['skip_delete'] is True:
+            self.params['test']['skip_teardown'] = True
+
+    def configure_device(self):
+        if self.params['device']['userdata'] is None:
+            self.params['device']['userdata'] = self.default_user_data()
+
+    def initial_test_config(self):
         return {
             'skip_delete': False,
             'skip_teardown': False,
-            'skip_dmsetup': False,
             'containerd_log_level': 'debug',
             'flintlock_log_level': '2',
         }
 
-    def default_device_config(self):
+    def initial_device_config(self):
         return {
+            'skip_dmsetup': False,
             'name': self.default_device_name(),
             'id': None,
             'ssh_key_name': self.generated_key_name(),
-            'userdata': self.default_user_data(),
+            'userdata': None,
             'plan': 'c3.small.x86',
             'operating_system': 'ubuntu_18_04',
             'metro': 'sv',
@@ -108,8 +118,13 @@ class Config:
         }
 
     def default_user_data(self):
-        files = ["hack/scripts/bootstrap.sh", "hack/scripts/direct_lvm.sh", "test/tools/config/userdata.sh"]
-        userdata = "#!/bin/bash\n export THINPOOL_DISK_NAME=sdb\n"
+        userdata = ""
+        files = ["hack/scripts/bootstrap.sh", "test/tools/config/userdata.sh"]
+
+        if self.params['device']['skip_dmsetup'] is False:
+            files.insert(1, "hack/scripts/direct_lvm.sh")
+            userdata += "#!/bin/bash\n export THINPOOL_DISK_NAME=sdb\n"
+
         for file in files:
             with open(self.base + "/" + file) as f:
                 userdata += f.read()

--- a/test/tools/config/schema.yaml
+++ b/test/tools/config/schema.yaml
@@ -7,10 +7,10 @@ device: include('device', required=False)
 test:
   skip_delete: bool(required=False)
   skip_teardown: bool(required=False)
-  skip_dmsetup: bool(required=False)
   containerd_log_level: str(required=False)
   flintlock_log_level: str(required=False)
 device:
+  skip_dmsetup: bool(required=False)
   name: str(required=False)
   id: str(required=False)
   ssh_key_name: str(required=False)

--- a/test/tools/example-config.yaml
+++ b/test/tools/example-config.yaml
@@ -5,10 +5,10 @@ project_id: "abcdef123456" # or project ID
 test:
   skip_delete: false # skip the test cleanup and process teardown steps
   skip_teardown: false # skip tearing down the equinix infra
-  skip_dmsetup: true # skip the thinpool setup, this should always be true for equinix
   containerd_log_level: "debug"
   flintlock_log_level: "2"
 device:
+  skip_dmsetup: false # skip the thinpool setup
   name: "test-device" # omit if device.id set
   id: "abcdef123456" # set if using existing device
   ssh_key_name: "test-key"

--- a/test/tools/test/runner.py
+++ b/test/tools/test/runner.py
@@ -1,11 +1,12 @@
 from metal.welder import Welder
 
 
+THINPOOL_NAME = "flintlock-thinpool"
+
 class Test:
     def __init__(self, auth_token, config):
         self.testCfg = config['test']
         devCfg = config['device']
-
         self.welder = Welder(auth_token, config)
         self.skip_teardown = self.testCfg['skip_teardown']
         self.dev_id = devCfg['id']
@@ -27,12 +28,12 @@ class Test:
         cmd = ['./test/e2e/test.sh',
                '-level.flintlockd', self.testCfg['flintlock_log_level'],
                '-level.containerd', self.testCfg['containerd_log_level'],
+               '-skip.setup.thinpool',
+               '-thinpool', THINPOOL_NAME
                ]
         if self.testCfg['skip_delete']:
             cmd.append('-skip.teardown')
             cmd.append('-skip.delete')
-        if self.testCfg['skip_dmsetup']:
-            cmd.append('-skip.setup.thinpool')
         try:
             self.welder.run_ssh_command(cmd, "/root/work/flintlock", False)
         except RuntimeError as e:


### PR DESCRIPTION
**What this PR does / why we need it**:

In the test code:
- Adds a new `-thinpool` custom flag to the e2e tests. This
  lets users set a thinpool name, useful for if they want to use
  one they made earlier or don't want to conflict with an
  existing one.
- If using with an existing one, users should set the
   `-skip.setup.thinpool` flag so they don't have some random
  pool made

In the python tool:
- Previously `skip_dmsetup` was under `test` in the tool config file. This
was to disable the loopdevice thinpool setup done by the e2e test suite.
Disabling the test level dmsetup should always be True when running in
Equinix, so I have hardcoded it.
- There may be a case in which the runner wants to disable the direct_lvm
thinpool setup, so that option is now available and grouped under
`device` in the config as it is relevant to the create command, not just
running the tests.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Part of https://github.com/weaveworks/flintlock/issues/146 follow on from https://github.com/weaveworks/flintlock/pull/265

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
