### PR TITLE
feat(test): Check capacity of facility before creating device

### DIFF
--- a/test/tools/config/config.py
+++ b/test/tools/config/config.py
@@ -61,17 +61,13 @@ class Config:
         self.params = always_merger.merge(self.params, data[0][0])
 
     def validate_run(self):
-        if self.params['org_id'] is None:
-            raise ValueError("must set org_id")
-
+        self.validate_common()
         self.configure_test()
         self.configure_device()
 
     def validate_create(self):
+        self.validate_common()
         self.configure_device()
-
-        if self.params['org_id'] is None:
-            raise ValueError("must set org_id")
 
         if self.params['project_id'] is None:
             raise ValueError("must set project_id")
@@ -82,6 +78,13 @@ class Config:
                     "Error validating config: device.id should not be set")
         except KeyError:
             pass
+
+    def validate_common(self):
+        if self.params['org_id'] is None:
+            raise ValueError("must set org_id")
+
+        if len(self.params['device']['facility']) < 1:
+            raise ValueError("must set at least one facility")
 
     def configure_test(self):
         if self.params['device']['id'] is not None:
@@ -111,9 +114,8 @@ class Config:
             'ssh_key_name': self.generated_key_name(),
             'userdata': None,
             'plan': 'c3.small.x86',
-            'operating_system': 'ubuntu_18_04',
-            'metro': 'sv',
-            'facility': 'am6',
+            'operating_system': 'ubuntu_20_10',
+            'facility': ['am6', 'ams1', 'fr2', 'fra2'],
             'billing_cycle': 'hourly'
         }
 

--- a/test/tools/config/schema.yaml
+++ b/test/tools/config/schema.yaml
@@ -16,7 +16,6 @@ device:
   ssh_key_name: str(required=False)
   userdata: str(required=False)
   plan: str(required=False)
-  metro: str(required=False)
+  facility: list(str(), required=False)
   operating_system: str(required=False)
-  facility: str(required=False)
   billing_cycle: str(required=False)

--- a/test/tools/example-config.yaml
+++ b/test/tools/example-config.yaml
@@ -15,8 +15,16 @@ device:
   # the following mirror the equinix options
   # see https://metal.equinix.com/developers/docs/ for values
   userdata: "echo hello"
-  plan: "c1.small.x86"
-  metro: "sv"
-  operating_system: "ubuntu_18_04"
-  facility: "ewr1"
+  # note: if setting up lvm thinpool, ensure that plan comes with at least
+  # one spare (unpartitioned and unmounted) disk
+  plan: "c3.small.x86"
+  # list of facilities to attempt device creation.
+  # minimum of 1 must be supplied
+  # note: ensure that the specified plan is availble in each facility
+  facility:
+  - "fr2"
+  - "fra2"
+  - "am6"
+  - "ams1"
+  operating_system: "ubuntu_20_10"
   billing_cycle: "hourly"

--- a/test/tools/metal/error.py
+++ b/test/tools/metal/error.py
@@ -1,0 +1,3 @@
+class CapacityError(Exception):
+    """Raised when Equinix cannot fulfill the request"""
+    pass

--- a/test/tools/run.py
+++ b/test/tools/run.py
@@ -4,6 +4,7 @@ from test.runner import Test
 from metal.welder import Welder
 from config.config import Config
 import click
+import json
 import os
 import sys
 import random
@@ -99,8 +100,9 @@ def create_device(config_file, org_id, project_id, ssh_key_name, device_name, us
         click.echo(str(e))
         sys.exit()
 
+    pretty = json.dumps(cfg['device'], indent=4)
     click.echo(
-        f"Creating device {cfg['device']['name']} with config {cfg['device']}")
+        f"Creating device {cfg['device']['name']} with config {pretty}")
 
     welder = Welder(token, cfg)
     ip = welder.create_all()


### PR DESCRIPTION
This changes the config so that a list of facilities will be tested to
ensure that there is capacity for device creation.

This gives us some resilience in the nightly e2e tests, although if
there is no capacity anywhere then they will still fail.

I had wanted to use a list of metros instead, which would have left
Equinix to find an appropriate facility, but the package I am using to
hit the Equinix API has a bug in that method (I've put in a PR). I have removed setting the
metro as an option as I did not feel like dealing with that logic right
now. Also I am not really sure which takes precedence if you set both on
the request. Metro I think?

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->
part of https://github.com/weaveworks/flintlock/issues/146

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
