### PR TITLE
feat(test): Add opts to configure repo and branch

### DIFF
--- a/.github/workflows/nightly_e2e.yml
+++ b/.github/workflows/nightly_e2e.yml
@@ -14,12 +14,24 @@ jobs:
     name: e2e tests
     steps:
     - uses: actions/checkout@v2
+
+    - name: Get branch name
+      id: branch-name
+      uses: tj-actions/branch-names@v5
+
     - name: Run tests
       env:
         METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}
       run: |
         pip3 install -r test/tools/requirements.txt
-        test/tools/run.py run-e2e -o ${{ secrets.EQUINIX_ORG_ID }} -p ${{ env.PROJECT_NAME }}
+        cat <<'EOF' >> e2e-config.yaml
+        ---
+        org_id: ${{ secrets.EQUINIX_ORG_ID }}
+        project_name: ${{ env.PROJECT_NAME }}
+        repo:
+          branch: ${{ steps.branch-name.outputs.current_branch }}
+        EOF
+        test/tools/run.py run-e2e -c e2e-config.yaml
 
     - name: Notify slack on failure
       uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a

--- a/test/tools/config/config.py
+++ b/test/tools/config/config.py
@@ -24,6 +24,7 @@ class Config:
             'org_id': None,
             'project_id': None,
             'project_name': self.generated_project_name(),
+            'repo': self.default_repo_config(),
             'device': self.initial_device_config(),
             'test': self.initial_test_config()
         }
@@ -98,6 +99,12 @@ class Config:
         if self.params['device']['userdata'] is None:
             self.params['device']['userdata'] = self.default_user_data()
 
+    def default_repo_config(self):
+        return {
+            'username': 'weaveworks',
+            'branch': 'main'
+        }
+
     def initial_test_config(self):
         return {
             'skip_delete': False,
@@ -125,7 +132,14 @@ class Config:
 
         if self.params['device']['skip_dmsetup'] is False:
             files.insert(1, "hack/scripts/direct_lvm.sh")
-            userdata += "#!/bin/bash\n export THINPOOL_DISK_NAME=sdb\n"
+            userdata += ("#!/bin/bash\n"
+                         "export THINPOOL_DISK_NAME=sdb\n"
+                         )
+
+        userdata += ("#!/bin/bash\n"
+                     f"export FL_USER={self.params['repo']['username']}\n"
+                     f"export FL_BRANCH={self.params['repo']['branch']}\n"
+                     )
 
         for file in files:
             with open(self.base + "/" + file) as f:

--- a/test/tools/config/schema.yaml
+++ b/test/tools/config/schema.yaml
@@ -1,9 +1,13 @@
 org_id: str(required=True)
 project_name: str(required=False)
 project_id: str(required=False)
+repo: include('repo', required=False)
 test: include('test', required=False)
 device: include('device', required=False)
 ---
+repo:
+  username: str(required=False)
+  branch: str(required=False)
 test:
   skip_delete: bool(required=False)
   skip_teardown: bool(required=False)

--- a/test/tools/config/userdata.sh
+++ b/test/tools/config/userdata.sh
@@ -1,9 +1,17 @@
-#!/bin/bash
+#!/bin/bash -ex
 
 mv /usr/local/go/bin/go /usr/local/bin
 
 mkdir -p /root/work && cd /root/work
-# TODO make it so that repo/branch etc can be configured for local runs / copy up binary / clone at commit etc
-git clone https://github.com/weaveworks/flintlock --depth 1
+
+if [[ -z $FL_USER ]];then
+    FL_USER=weaveworks
+fi
+
+if [[ -z "$FL_BRANCH" ]]; then
+    FL_BRANCH=main
+fi
+
+git clone "https://github.com/$FL_USER/flintlock" --depth 1 --branch "$FL_BRANCH"
 
 touch /flintlock_ready

--- a/test/tools/example-config.yaml
+++ b/test/tools/example-config.yaml
@@ -2,6 +2,9 @@
 org_id: "test-org" # required
 project_name: "test-project" # or project ID
 project_id: "abcdef123456" # or project ID
+repo:
+  username: "weaveworks" # username of flinklock repo to clone on device
+  branch: "main" # clone flintlock at this branch
 test:
   skip_delete: false # skip the test cleanup and process teardown steps
   skip_teardown: false # skip tearing down the equinix infra


### PR DESCRIPTION
Config:
```yaml
repo:
  username: callisto13
  branch: my-test-branch
```
will clone my fork of flintlock at that branch onto the created device

Just a nice to have when creating the device.

Useful for when running the e2es on a branch (of the upstream repo),
otherwise it will just be main cloned down and tested.

For more flexibility I am going to add a further option which will scp a
built binary (or a full tar of the local repo, can't decide yet) to make local
dev turnaround even faster.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/weaveworks/flintlock/issues/146

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
