### PR TITLE
fix: MicroVM can't be deleted if it failed to create too many times

### DIFF
--- a/core/application/commands.go
+++ b/core/application/commands.go
@@ -54,6 +54,7 @@ func (a *app) CreateMicroVM(ctx context.Context, mvm *models.MicroVM) (*models.M
 	// Set the timestamp when the VMspec was created.
 	mvm.Spec.CreatedAt = a.ports.Clock().Unix()
 	mvm.Status.State = models.PendingState
+	mvm.Status.Retry = 0
 
 	createdMVM, err := a.ports.Repo.Save(ctx, mvm)
 	if err != nil {
@@ -95,6 +96,7 @@ func (a *app) DeleteMicroVM(ctx context.Context, id, namespace string) error {
 
 	// Set the timestamp when the VMspec was deleted.
 	foundMvm.Spec.DeletedAt = a.ports.Clock().Unix()
+	foundMvm.Status.Retry = 0
 
 	_, err = a.ports.Repo.Save(ctx, foundMvm)
 	if err != nil {

--- a/hack/scripts/payload/CreateMicroVM.json
+++ b/hack/scripts/payload/CreateMicroVM.json
@@ -17,10 +17,9 @@
       "image": "docker.io/richardcase/ubuntu-bionic-kernel:0.0.11",
       "filename": "initrd-generic"
     },
-    "volumes": [
+    "rootVolume": [
       {
         "id": "root",
-        "is_root": true,
         "is_read_only": false,
         "mount_point": "/",
         "source": {
@@ -30,16 +29,8 @@
     ],
     "interfaces": [
       {
-        "guest_device_name": "eth0",
-        "type": 1,
-        "allow_metadata_req": true,
-        "guest_mac": "AA:FF:00:00:00:01",
-        "address": "169.254.0.1/16"
-      },
-      {
         "guest_device_name": "eth1",
-        "type": 0,
-        "allow_metadata_req": false
+        "type": 0
       }
     ],
     "metadata": {


### PR DESCRIPTION
**What this PR does / why we need it**:

* Set `Retry` on calling Create or Delete endpoints.
* Fix CreateMicroVM payload under `hack/scripts/payload/`, it was not updated in #271 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #276

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
