### PR TITLE
fix: root volume mount host path

### DIFF
--- a/infrastructure/firecracker/config.go
+++ b/infrastructure/firecracker/config.go
@@ -61,11 +61,16 @@ func WithMicroVM(vm *models.MicroVM) ConfigOption {
 
 		cfg.BlockDevices = []BlockDeviceConfig{}
 
+		rootVolumeStatus, volumeStatusFound := vm.Status.Volumes[vm.Spec.RootVolume.ID]
+		if !volumeStatusFound {
+			return errors.NewVolumeNotMounted(vm.Spec.RootVolume.ID)
+		}
+
 		cfg.BlockDevices = append(cfg.BlockDevices, BlockDeviceConfig{
 			ID:           vm.Spec.RootVolume.ID,
 			IsReadOnly:   vm.Spec.RootVolume.IsReadOnly,
 			IsRootDevice: true,
-			PathOnHost:   vm.Spec.RootVolume.MountPoint,
+			PathOnHost:   rootVolumeStatus.Mount.Source,
 			CacheType:    CacheTypeUnsafe,
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix this error:
```
ERRO[0005] failed to reconcile vmid ns1/mvm1: executing plan: executing plan steps: executing steps: executing step microvm_create: creating microvm: applying firecracker configuration: putting drive configuration: [PUT /drives/{drive_id}][400] putGuestDriveByIdBadRequest  &{FaultMessage:Unable to seek the block device backing file due to invalid permissions or the file was corrupted. Error number: Is a directory (os error 21)}  controller=microvm
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

<s> I know it has zero check if RootVolume is there or not, but
1. We have validation it has to be there, most likely
2. It does not work at all now
3. We (will) have a backfill ticket on tests, that can improve this.
4. Because of "2." a lot of work is blocked.</s>

```
INFO[0003] started executing plan                        controller=microvm execution_id=01FN6K66S645PWP7AC3M8X0Z47 plan_name=microvm_create_update
INFO[0003] checking state of microvm                     controller=microvm service=firecracker_microvm vmid=ns1/mvm1
INFO[0003] checking state of microvm                     controller=microvm service=firecracker_microvm vmid=ns1/mvm1
INFO[0003] checking state of microvm                     controller=microvm service=firecracker_microvm vmid=ns1/mvm1
INFO[0004] checking state of microvm                     controller=microvm service=firecracker_microvm vmid=ns1/mvm1
INFO[0004] starting microvm                              controller=microvm service=firecracker_microvm vmid=ns1/mvm1
INFO[0004] checking state of microvm                     controller=microvm service=firecracker_microvm vmid=ns1/mvm1
INFO[0004] started microvm                               controller=microvm service=firecracker_microvm vmid=ns1/mvm1
INFO[0009] checking state of microvm                     controller=microvm service=firecracker_microvm vmid=ns1/mvm1
INFO[0009] checking state of microvm                     controller=microvm service=firecracker_microvm vmid=ns1/mvm1
INFO[0009] checking state of microvm                     controller=microvm service=firecracker_microvm vmid=ns1/mvm1
INFO[0009] finished executing plan                       controller=microvm execution_id=01FN6K66S645PWP7AC3M8X0Z47 execution_time=5.68639758s num_steps=7 plan_name=microvm_create_update
```

**Checklist**:

- [x] squashed commits into logical changes