### PR TITLE
Make sure a mvm is properly stopped

### DIFF
--- a/internal/command/run/run.go
+++ b/internal/command/run/run.go
@@ -68,6 +68,7 @@ func NewCommand(cfg *config.Config) (*cobra.Command, error) {
 
 	cmd.Flags().StringVar(&cfg.StateRootDir, "state-dir", defaults.StateRootDir, "The directory to use for the as the root for runtime state.")
 	cmd.Flags().DurationVar(&cfg.ResyncPeriod, "resync-period", defaults.ResyncPeriod, "Reconcile the specs to resynchronise them based on this period.")
+	cmd.Flags().DurationVar(&cfg.DeleteVMTimeout, "deleteMicroVM-timeout", defaults.DeleteVMTimeout, "The timeout for deleting a microvm.")
 
 	return cmd, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,4 +40,6 @@ type Config struct {
 	ResyncPeriod time.Duration
 	// MaximumRetry defined how many times we retry if reconciliation failed.
 	MaximumRetry int
+	// DeleteVMTimeout defines the timeout for the delete vm operation.
+	DeleteVMTimeout time.Duration
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -48,6 +48,9 @@ const (
 	// ResyncPeriod is the default resync period duration.
 	ResyncPeriod time.Duration = 10 * time.Minute
 
+	// DeleteVMTimeout is the default timeout for deleting a microvm.
+	DeleteVMTimeout time.Duration = 10 * time.Second
+
 	// DataDirPerm is the permissions to use for data folders.
 	DataDirPerm = 0o755
 

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -1,11 +1,16 @@
 package process
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 )
+
+// errWaitProcessNotFound is returned when wait() does not find the process.
+const errWaitProcessNotFound = "no child processes"
 
 // DetachedStart will start a subprocess in detached mode.
 func DetachedStart(cmd *exec.Cmd) error {
@@ -50,7 +55,7 @@ func SendSignal(pid int, sig os.Signal) error {
 		return fmt.Errorf("unable to find process (%d): %w", pid, err)
 	}
 
-	if err := proc.Signal(os.Interrupt); err != nil {
+	if err := proc.Signal(sig); err != nil {
 		return fmt.Errorf(
 			"unable to send signal to process (%s): %w",
 			sig.String(),
@@ -59,4 +64,46 @@ func SendSignal(pid int, sig os.Signal) error {
 	}
 
 	return nil
+}
+
+// WaitWithContext will wait for a process to exit.
+// It will return the exit code of the process.
+func WaitWithContext(ctx context.Context, pid int) error {
+	// on Unix system os.FindProcess() is always successful
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("unable to find process (%d): %w", pid, err)
+	}
+
+	exited := make(chan error)
+
+	go func() {
+		_, err := proc.Wait()
+		if err != nil {
+			exited <- fmt.Errorf("wait for process (%d): %w", pid, err)
+		}
+		exited <- nil
+	}()
+
+	select {
+	case err := <-exited:
+		return err
+	case <-ctx.Done():
+		// If the context is canceled, we need to kill the process.
+		// This is a best effort attempt.
+		// It only kills the child process, not its children.
+		if err := proc.Kill(); err != nil {
+			return fmt.Errorf("unable to kill process (%d): %w", pid, err)
+		}
+
+		// release the pid
+		if _, err := proc.Wait(); err != nil {
+			// ignore error if process is already cleaned up
+			if !strings.Contains(err.Error(), errWaitProcessNotFound) {
+				return fmt.Errorf("unable to release process (%d): %w", pid, err)
+			}
+		}
+
+		return nil
+	}
 }

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -1,0 +1,78 @@
+package process_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	g "github.com/onsi/gomega"
+	"github.com/weaveworks/flintlock/pkg/process"
+)
+
+func TestSendSignal(t *testing.T) {
+	g.RegisterTestingT(t)
+
+	//create a new process
+	p := exec.Command("sleep", "10")
+
+	//start the process
+	err := p.Start()
+	g.Expect(err).NotTo(g.HaveOccurred())
+
+	err = process.SendSignal(p.Process.Pid, os.Kill)
+	g.Expect(err).NotTo(g.HaveOccurred())
+
+	//release the pid
+	p.Wait()
+
+	//check if process exists
+	exists, err := process.Exists(p.Process.Pid)
+	g.Expect(err).NotTo(g.HaveOccurred())
+	g.Expect(exists).To(g.BeFalse())
+}
+
+func TestWaitWithContext(t *testing.T) {
+	g.RegisterTestingT(t)
+
+	testCases := []struct {
+		name    string
+		command string
+		timeout int
+	}{
+		{
+			name:    "wait on a process that does not exist",
+			command: "sleep 5 & echo $! | xargs -I{} kill -9 {}",
+			timeout: 5,
+		},
+		{
+			name:    "wait on a process that exists, should succeed",
+			command: "sleep 10",
+			timeout: 5,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := exec.Command("bash", "-c", tc.command)
+
+			err := p.Start()
+			g.Expect(err).NotTo(g.HaveOccurred())
+
+			//wait on the process
+			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(tc.timeout)*time.Second)
+			defer cancel()
+
+			// expected to kill the process after timeout
+			// as we did not send any signal
+			err = process.WaitWithContext(ctx, p.Process.Pid)
+			g.Expect(err).NotTo(g.HaveOccurred())
+
+			//check if process exists
+			exists, err := process.Exists(p.Process.Pid)
+			g.Expect(err).NotTo(g.HaveOccurred())
+			g.Expect(exists).To(g.BeFalse())
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Soule BA <soule@weave.works>

kind/bug


**What this PR does / why we need it**:

If implemented this will add a wait command to make sure a mvm is
stopped before resuming the deletion plan.

**Which issue(s) this PR fixes**:
Fixes #225

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests