### PR TITLE
fix: remove socket check from e2e

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -49,9 +49,6 @@ func TestE2E(t *testing.T) {
 
 	log.Println("TEST STEP: getting (and verifying) existing MicroVM")
 	Eventually(func(g Gomega) error {
-		// verify that the socket exists
-		g.Expect(fmt.Sprintf(fcPath, mvmNS, mvmID) + "/firecracker.sock").To(BeAnExistingFile())
-
 		// verify that firecracker has started and that a pid has been saved
 		// and that there is actually a running process
 		mvmPid1 = u.ReadPID(fmt.Sprintf(fcPath, mvmNS, mvmID))
@@ -70,9 +67,6 @@ func TestE2E(t *testing.T) {
 
 	log.Println("TEST STEP: listing all MicroVMs")
 	Eventually(func(g Gomega) error {
-		// verify that the new socket exists
-		g.Expect(fmt.Sprintf(fcPath, mvmNS, secondMvmID) + "/firecracker.sock").To(BeAnExistingFile())
-
 		// verify that firecracker has started and that a pid has been saved
 		// and that there is actually a running process for the new mVM
 		mvmPid2 = u.ReadPID(fmt.Sprintf(fcPath, mvmNS, secondMvmID))


### PR DESCRIPTION
**What this PR does / why we need it**:

In #288 we removed the socket API listening completely.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
https://pipelines.actions.githubusercontent.com/RkoJIwCv3SRvW0kQqNZsTjV9Lz9BzqDQgnc5BmuU3NzLtEIoEZ/_apis/pipelines/1/runs/3860/signedlogcontent/2?urlExpires=2021-11-30T08%3A25%3A38.8921725Z&urlSigningMethod=HMACV1&urlSignature=LOPkEpHzE%2FjHpz8wYheBl4O%2FsB5XKeE%2FhsPIS7IgdzY%3D

```
time="2021-11-30T00:13:59.703190272Z" level=debug msg="(*service).Write started" ref=works.weave.flintlockd/microvm/ns0/mvm0
    e2e_test.go:65: 
        Timed out after 120.000s.
        Error: Assertion in callback at /root/work/flintlock/test/e2e/e2e_test.go:53 failed:
        Expected
            <string>: /var/lib/flintlock/vm/ns0/mvm0/firecracker.sock
        to exist
```

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
