### PR TITLE
Set MVM state to 'created' only on plan success

### DIFF
--- a/core/application/reconcile.go
+++ b/core/application/reconcile.go
@@ -123,6 +123,10 @@ func (a *app) reconcile(ctx context.Context, spec *models.MicroVM, logger *logru
 
 		logger.Error(reachedMaximumRetryError{vmid: spec.ID, retries: spec.Status.Retry})
 
+		if _, err := a.ports.Repo.Save(ctx, spec); err != nil {
+			return fmt.Errorf("saving spec after plan execution: %w", err)
+		}
+
 		return nil
 	}
 

--- a/core/models/microvm.go
+++ b/core/models/microvm.go
@@ -1,5 +1,7 @@
 package models
 
+// This state represents the state of the entire Flintlock MVM.
+// The state for the Firecracker MVM itself is represented in ports.MicroVMState.
 type MicroVMState string
 
 const (

--- a/core/plans/microvm_create_update.go
+++ b/core/plans/microvm_create_update.go
@@ -82,8 +82,8 @@ func (p *microvmCreateOrUpdatePlan) Create(ctx context.Context) ([]planner.Proce
 	return p.steps, nil
 }
 
-func (p *microvmCreateOrUpdatePlan) Result() interface{} {
-	return nil
+func (p *microvmCreateOrUpdatePlan) Finalise(state models.MicroVMState) {
+	p.vm.Status.State = state
 }
 
 // This is the most important function in the codebase DO NOT REMOVE
@@ -184,9 +184,7 @@ func (p *microvmCreateOrUpdatePlan) ensureStatus() {
 		p.vm.Status.NetworkInterfaces = models.NetworkInterfaceStatuses{}
 	}
 
-	// I'll leave this condition here for safety. If (for some reason) it's
-	// called on a vm that's not pending, leave the status as it is.
-	if p.vm.Status.State == models.PendingState {
-		p.vm.Status.State = models.CreatedState
-	}
+	// If we are going through the create/update steps, then switch to pending first.
+	// When all is done and successful it will be put to created.
+	p.vm.Status.State = models.PendingState
 }

--- a/core/plans/microvm_delete.go
+++ b/core/plans/microvm_delete.go
@@ -93,9 +93,7 @@ func (p *microvmDeletePlan) Create(ctx context.Context) ([]planner.Procedure, er
 	return p.steps, nil
 }
 
-// Result is the result of the plan.
-func (p *microvmDeletePlan) Result() interface{} {
-	return nil
+func (p *microvmDeletePlan) Finalise(_ models.MicroVMState) {
 }
 
 // This is the most important function in the codebase DO NOT REMOVE

--- a/core/ports/services.go
+++ b/core/ports/services.go
@@ -29,6 +29,8 @@ type MicroVMService interface {
 	State(ctx context.Context, id string) (MicroVMState, error)
 }
 
+// This state represents the state of the Firecracker MVM process itself
+// The state for the entire Flintlock MVM is represented in models.MicroVMState.
 type MicroVMState string
 
 const (

--- a/infrastructure/grpc/convert.go
+++ b/infrastructure/grpc/convert.go
@@ -237,10 +237,10 @@ func convertModelToMicroVMStatus(mvm *models.MicroVM) *types.MicroVMStatus {
 	}
 
 	switch mvm.Status.State {
-	case models.CreatedState:
-		converted.State = types.MicroVMStatus_CREATED
 	case models.PendingState:
 		converted.State = types.MicroVMStatus_PENDING
+	case models.CreatedState:
+		converted.State = types.MicroVMStatus_CREATED
 	case models.FailedState:
 		converted.State = types.MicroVMStatus_FAILED
 	case models.DeletingState:

--- a/pkg/planner/actuator_test.go
+++ b/pkg/planner/actuator_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/weaveworks/flintlock/core/models"
 	"github.com/weaveworks/flintlock/infrastructure/ulid"
 	"github.com/weaveworks/flintlock/pkg/planner"
 )
@@ -142,8 +143,7 @@ func (tp *testPlan) Create(ctx context.Context) ([]planner.Procedure, error) {
 	return toExec, nil
 }
 
-func (tp *testPlan) Result() interface{} {
-	return nil
+func (tp *testPlan) Finalise(_ models.MicroVMState) {
 }
 
 func newTestProc(delay time.Duration, childProcs []planner.Procedure) planner.Procedure {

--- a/pkg/planner/planner.go
+++ b/pkg/planner/planner.go
@@ -1,6 +1,10 @@
 package planner
 
-import "context"
+import (
+	"context"
+
+	"github.com/weaveworks/flintlock/core/models"
+)
 
 // NOTE: this is based on this prior work https://gianarb.it/blog/reactive-plan-golang-example
 // which has been adapted for use here.
@@ -13,6 +17,9 @@ type Plan interface {
 	// Create will perform the plan and will return a list of operations/procedures
 	// that need to be run to accomplish the plan
 	Create(ctx context.Context) ([]Procedure, error)
+
+	// Finalise will set final status fields when the Plan is complete
+	Finalise(state models.MicroVMState)
 }
 
 // Procedure represents a procedure/operation that will be carried out


### PR DESCRIPTION
**What this PR does / why we need it**:

4 small related pieces:

Set state to CREATED only on success

 Previously we would set 'created' before any of the create steps were
 even executed. Here we instead set the state to 'pending' before the
 plan is compiled, and graduate to 'created' only when all steps are
 complete and successful.

--

Save failed state when all create attempts fail

--

Add some more descriptive comments

To help clarify the different levels of state we have:
- The Firecracker state
- The overall (and much less verbose) Flintlock status

-- 

Reorganise grpc state conversion

It's just tidier to go in numerical order




**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/weaveworks/flintlock/issues/313

**Special notes for your reviewer**:

I wanted to add tests ,but we dont have any in place around reconciliation and I wasn;t feeling that generous. 

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
