### PR TITLE
refactor: cloudinit pointer removal

### DIFF
--- a/client/cloudinit/doc.go
+++ b/client/cloudinit/doc.go
@@ -1,0 +1,7 @@
+// Package cloudinit contains types related to [cloudinit](https://cloudinit.readthedocs.io/en/latest/index.html)
+// to be used by flintlock and its clients.
+//
+// In the struct definitions we have tried to remove usage of pointers and instead rely on the behavior of json
+// marshalling and `omitempty`. Its slightly tricky with boolean values so for these we use *bool vs bool. The
+// reason is that the default value for some cloudinit values is true which isn't the same as the default for bool.
+package cloudinit

--- a/client/cloudinit/metadata.go
+++ b/client/cloudinit/metadata.go
@@ -4,4 +4,5 @@ type Metadata struct {
 	InstanceID    string `yaml:"instance_id"`
 	LocalHostname string `yaml:"local_hostname"`
 	Platform      string `yaml:"platform"`
+	ClusterName   string `yaml:"cluster_name"`
 }

--- a/client/cloudinit/network.go
+++ b/client/cloudinit/network.go
@@ -1,23 +1,23 @@
 package cloudinit
 
 type Network struct {
-	Version  int                  `yaml:"version"`
-	Ethernet map[string]*Ethernet `yaml:"ethernets"`
+	Version  int                 `yaml:"version"`
+	Ethernet map[string]Ethernet `yaml:"ethernets"`
 }
 
 type Ethernet struct {
-	Match       Match        `yaml:"match"`
-	Addresses   []string     `yaml:"addresses,omitempty"`
-	GatewayIPv4 *string      `yaml:"gateway4,omitempty"`
-	GatewayIPv6 *string      `yaml:"gateway6,omitempty"`
-	DHCP4       *bool        `yaml:"dhcp4,omitempty"`
-	DHCP6       *bool        `yaml:"dhcp6,omitempty"`
-	Nameservers *Nameservers `yaml:"nameservers,omitempty"`
+	Match       Match       `yaml:"match"`
+	Addresses   []string    `yaml:"addresses,omitempty"`
+	GatewayIPv4 string      `yaml:"gateway4,omitempty"`
+	GatewayIPv6 string      `yaml:"gateway6,omitempty"`
+	DHCP4       *bool       `yaml:"dhcp4,omitempty"`
+	DHCP6       *bool       `yaml:"dhcp6,omitempty"`
+	Nameservers Nameservers `yaml:"nameservers,omitempty"`
 }
 
 type Match struct {
-	MACAddress *string `yaml:"macaddress,omitempty"`
-	Name       *string `yaml:"name,omitempty"`
+	MACAddress string `yaml:"macaddress,omitempty"`
+	Name       string `yaml:"name,omitempty"`
 }
 
 type Nameservers struct {

--- a/client/cloudinit/userdata.go
+++ b/client/cloudinit/userdata.go
@@ -1,25 +1,25 @@
 package cloudinit
 
 type UserData struct {
-	HostName        *string      `yaml:"hostname,omitempty"`
-	Fqdn            *string      `yaml:"fqdn,omitempty"`
-	Users           *[]User      `yaml:"users,omitempty"`
-	SSHPasswordAuth *bool        `yaml:"ssh_pwauth,omitempty"`
-	DisableRoot     *bool        `yaml:"disable_root,omitempty"`
-	PackageUpdate   *bool        `yaml:"package_update,omitempty"`
-	FinalMessage    *string      `yaml:"final_message,omitempty"`
-	WriteFiles      *[]WriteFile `yaml:"write_files,omitempty"`
-	RunCommands     *[]string    `yaml:"runcmd,omitempty"`
+	HostName        string      `yaml:"hostname,omitempty"`
+	Fqdn            string      `yaml:"fqdn,omitempty"`
+	Users           []User      `yaml:"users,omitempty"`
+	SSHPasswordAuth *bool       `yaml:"ssh_pwauth,omitempty"`
+	DisableRoot     *bool       `yaml:"disable_root,omitempty"`
+	PackageUpdate   *bool       `yaml:"package_update,omitempty"`
+	FinalMessage    string      `yaml:"final_message,omitempty"`
+	WriteFiles      []WriteFile `yaml:"write_files,omitempty"`
+	RunCommands     []string    `yaml:"runcmd,omitempty"`
 }
 
 type User struct {
-	Name              string    `yaml:"name"`
-	Sudo              *string   `yaml:"sudo,omitempty"`
-	Groups            *string   `yaml:"groups,omitempty"`
-	Home              *string   `yaml:"home,omitempty"`
-	Shell             *string   `yaml:"shell,omitempty"`
-	LockPasswd        *bool     `yaml:"lock_passwd,omitempty"`
-	SSHAuthorizedKeys *[]string `yaml:"ssh_authorized_keys,omitempty"`
+	Name              string   `yaml:"name"`
+	Sudo              string   `yaml:"sudo,omitempty"`
+	Groups            string   `yaml:"groups,omitempty"`
+	Home              string   `yaml:"home,omitempty"`
+	Shell             string   `yaml:"shell,omitempty"`
+	LockPasswd        *bool    `yaml:"lock_passwd,omitempty"`
+	SSHAuthorizedKeys []string `yaml:"ssh_authorized_keys,omitempty"`
 }
 
 type WriteFile struct {

--- a/infrastructure/firecracker/config.go
+++ b/infrastructure/firecracker/config.go
@@ -154,7 +154,7 @@ func createNetworkIface(iface *models.NetworkInterface, status *models.NetworkIn
 func generateNetworkConfig(vm *models.MicroVM) (string, error) {
 	network := &cloudinit.Network{
 		Version:  cloudInitNetVersion,
-		Ethernet: map[string]*cloudinit.Ethernet{},
+		Ethernet: map[string]cloudinit.Ethernet{},
 	}
 
 	for i := range vm.Spec.NetworkInterfaces {
@@ -174,9 +174,9 @@ func generateNetworkConfig(vm *models.MicroVM) (string, error) {
 		}
 
 		if macAddress != "" {
-			eth.Match.MACAddress = &macAddress
+			eth.Match.MACAddress = macAddress
 		} else {
-			eth.Match.Name = &iface.GuestDeviceName
+			eth.Match.Name = iface.GuestDeviceName
 		}
 
 		if iface.StaticAddress != nil {
@@ -185,7 +185,7 @@ func generateNetworkConfig(vm *models.MicroVM) (string, error) {
 			}
 		}
 
-		network.Ethernet[iface.GuestDeviceName] = eth
+		network.Ethernet[iface.GuestDeviceName] = *eth
 	}
 
 	nd, err := yaml.Marshal(network)
@@ -211,14 +211,14 @@ func configureStaticEthernet(iface *models.NetworkInterface, eth *cloudinit.Ethe
 		}
 
 		if isIPv4 {
-			eth.GatewayIPv4 = &ipAddr
+			eth.GatewayIPv4 = ipAddr
 		} else {
-			eth.GatewayIPv6 = &ipAddr
+			eth.GatewayIPv6 = ipAddr
 		}
 	}
 
 	if len(iface.StaticAddress.Nameservers) > 0 {
-		eth.Nameservers = &cloudinit.Nameservers{
+		eth.Nameservers = cloudinit.Nameservers{
 			Addresses: []string{},
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

A small refactor to the **cloudinit** package to remove pointers where
possible so that its more user friendly to consume.

In the struct definitions we have tried to remove usage of pointers and instead rely on the behavior of json
marshalling and `omitempty`. Its slightly tricky with boolean values so for these we use *bool vs bool. The
reason is that the default value for some cloudinit values is true which isn't the same as the default for bool.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
