### PR TITLE
Add service file for systemd

### DIFF
--- a/flintlockd.service
+++ b/flintlockd.service
@@ -1,0 +1,34 @@
+# Copyright The flintlock Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=flintlock microvm service
+Documentation=https://docs.flintlock.dev/
+Requires=containerd.service
+
+[Service]
+ExecStartPre=which firecracker
+ExecStartPre=which flintlockd
+ExecStart=/usr/local/bin/flintlockd run \
+        --containerd-socket=/run/containerd/containerd.sock \
+        --grpc-endpoint=0.0.0.0:9090 \
+        --verbosity=9 \
+        --parent-iface=PARENT_IFACE
+Restart=always
+RestartSec=5
+User=root
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
As part of my docs writing I realised that having an option to manage flintlockd with systemd looks a bit more pro than "start the server with an `&`".

The `--parent-iface` flag is of course required and means some sort of user input. I did consider an EnvironmentFile, but it's a bit "eh" and the systemd creators deeply regret its inclusion.
I am documenting that users need to do something here.