### PR TITLE
refector: remove pause/result from provider interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ generate: ## Generate code
 
 .PHONY: generate-go
 generate-go: $(MOCKGEN) ## Generate Go Code
-	go generate ./...
+	go generate ./... -mod=mod
 
 .PHONY: generate-proto ## Generate protobuf/grpc code
 generate-proto: $(BUF) $(PROTOC_GEN_GO) $(PROTOC_GEN_GO_GRPC) $(PROTO_GEN_GRPC_GW) $(PROTO_GEN_GRPC_OAPI) $(PROTOC_GEN_DOC)

--- a/core/ports/services.go
+++ b/core/ports/services.go
@@ -13,18 +13,12 @@ type MicroVMService interface {
 	// Capabilities returns a list of the capabilities the provider supports.
 	Capabilities() models.Capabilities
 
-	// CreateVM will create a new microvm.
+	// Create will create a new microvm.
 	Create(ctx context.Context, vm *models.MicroVM) error
-	// DeleteVM will delete a VM and its runtime state.
+	// Delete will delete a VM and its runtime state.
 	Delete(ctx context.Context, id string) error
-	// StartVM will start a created microvm.
+	// Start will start a created microvm.
 	Start(ctx context.Context, vm *models.MicroVM) error
-	// PauseVM will pause a started microvm.
-	Pause(ctx context.Context, id string) error
-	// ResumeVM will resume a paused microvm.
-	Resume(ctx context.Context, id string) error
-	// StopVM will stop a paused or running microvm.
-	Stop(ctx context.Context, id string) error
 	// State returns the state of a microvm.
 	State(ctx context.Context, id string) (MicroVMState, error)
 }
@@ -38,7 +32,6 @@ const (
 	MicroVMStatePending    MicroVMState = "pending"
 	MicroVMStateConfigured MicroVMState = "configured"
 	MicroVMStateRunning    MicroVMState = "running"
-	MicroVMStatePaused     MicroVMState = "paused"
 )
 
 // MicroVMGRPCService is a port for a microvm grpc service.

--- a/core/steps/microvm/create_test.go
+++ b/core/steps/microvm/create_test.go
@@ -77,7 +77,6 @@ func TestNewCreateStep_StateCheck(t *testing.T) {
 		{State: ports.MicroVMStatePending, ExpectToRun: true},
 		{State: ports.MicroVMStateConfigured, ExpectToRun: false},
 		{State: ports.MicroVMStateRunning, ExpectToRun: false},
-		{State: ports.MicroVMStatePaused, ExpectToRun: false},
 		{State: ports.MicroVMStateUnknown, ExpectToRun: false},
 	}
 

--- a/core/steps/microvm/delete_test.go
+++ b/core/steps/microvm/delete_test.go
@@ -78,7 +78,6 @@ func TestNewDeleteStep_StateCheck(t *testing.T) {
 		{State: ports.MicroVMStatePending, ExpectToRun: false},
 		{State: ports.MicroVMStateConfigured, ExpectToRun: true},
 		{State: ports.MicroVMStateRunning, ExpectToRun: true},
-		{State: ports.MicroVMStatePaused, ExpectToRun: true},
 		{State: ports.MicroVMStateUnknown, ExpectToRun: false},
 	}
 

--- a/core/steps/microvm/start_test.go
+++ b/core/steps/microvm/start_test.go
@@ -84,7 +84,6 @@ func TestNewStartStep_StateCheck(t *testing.T) {
 		{State: ports.MicroVMStatePending, ExpectToRun: true},
 		{State: ports.MicroVMStateConfigured, ExpectToRun: true},
 		{State: ports.MicroVMStateRunning, ExpectToRun: false},
-		{State: ports.MicroVMStatePaused, ExpectToRun: true},
 		{State: ports.MicroVMStateUnknown, ExpectToRun: true},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.10.0
 	github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852
-	github.com/weaveworks/flintlock/api v0.0.0-00010101000000-000000000000
 	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d // indirect
 	google.golang.org/grpc v1.42.0
 	google.golang.org/protobuf v1.27.1
@@ -77,6 +76,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/subcommands v1.0.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
@@ -94,6 +94,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
 	github.com/opencontainers/selinux v1.8.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
@@ -101,12 +102,16 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae // indirect
+	github.com/weaveworks/flintlock/api v0.0.0-20211217111250-5f8d70c4a581 // indirect
 	go.mongodb.org/mongo-driver v1.7.5 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
+	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d // indirect
 	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/tools v0.1.2 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -546,6 +546,7 @@ github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/subcommands v1.0.1 h1:/eqq+otEXm5vhfBrbREPCSVQbvofip6kIz+mX5TUH7k=
 github.com/google/subcommands v1.0.1/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -1072,6 +1073,7 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.5.0/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1349,6 +1351,7 @@ golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.2 h1:kRBLX7v7Af8W7Gdbbc908OJcdgtK8bOz9Uaj8/F1ACA=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=

--- a/infrastructure/firecracker/provider.go
+++ b/infrastructure/firecracker/provider.go
@@ -2,7 +2,6 @@ package firecracker
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"syscall"
 	"time"
@@ -15,8 +14,6 @@ import (
 	"github.com/weaveworks/flintlock/pkg/log"
 	"github.com/weaveworks/flintlock/pkg/process"
 )
-
-var errNotImplemeted = errors.New("not implemented")
 
 // Config represents the configuration options for the Firecracker infrastructure.
 type Config struct {
@@ -53,7 +50,7 @@ func (p *fcProvider) Capabilities() models.Capabilities {
 	return models.Capabilities{models.MetadataServiceCapability}
 }
 
-// StartVM will start a created microvm.
+// Start will start a created microvm.
 // With configuration file, we don't really have start.  A separate Start and
 // Create steps is a good idea, but the right now steps are still coupled with
 // MicroVM.
@@ -71,22 +68,7 @@ func (p *fcProvider) Start(ctx context.Context, vm *models.MicroVM) error {
 	return p.Create(ctx, vm)
 }
 
-// Pause will pause a started microvm.
-func (p *fcProvider) Pause(ctx context.Context, id string) error {
-	return errNotImplemeted
-}
-
-// Resume will resume a paused microvm.
-func (p *fcProvider) Resume(ctx context.Context, id string) error {
-	return errNotImplemeted
-}
-
-// Stop will stop a paused or running microvm.
-func (p *fcProvider) Stop(ctx context.Context, id string) error {
-	return errNotImplemeted
-}
-
-// Delete will delete a VM and its runtime state.
+// Stop will stop a running microvm.
 func (p *fcProvider) Delete(ctx context.Context, id string) error {
 	logger := log.GetLogger(ctx).WithFields(logrus.Fields{
 		"service": "firecracker_microvm",

--- a/infrastructure/mock/ports.go
+++ b/infrastructure/mock/ports.go
@@ -78,34 +78,6 @@ func (mr *MockMicroVMServiceMockRecorder) Delete(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockMicroVMService)(nil).Delete), arg0, arg1)
 }
 
-// Pause mocks base method.
-func (m *MockMicroVMService) Pause(arg0 context.Context, arg1 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Pause", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Pause indicates an expected call of Pause.
-func (mr *MockMicroVMServiceMockRecorder) Pause(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pause", reflect.TypeOf((*MockMicroVMService)(nil).Pause), arg0, arg1)
-}
-
-// Resume mocks base method.
-func (m *MockMicroVMService) Resume(arg0 context.Context, arg1 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Resume", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Resume indicates an expected call of Resume.
-func (mr *MockMicroVMServiceMockRecorder) Resume(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resume", reflect.TypeOf((*MockMicroVMService)(nil).Resume), arg0, arg1)
-}
-
 // Start mocks base method.
 func (m *MockMicroVMService) Start(arg0 context.Context, arg1 *models.MicroVM) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**What this PR does / why we need it**:

As we are not supporting pausing / resuming microvms at this stage these
functions have been removed from the microvm provider interface. The
firecracker implementation has these removed as well and any tests have
been updated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
