### PR TITLE
feat: exposing bootcmd cloud-init option

### DIFF
--- a/client/cloudinit/userdata.go
+++ b/client/cloudinit/userdata.go
@@ -10,6 +10,9 @@ type UserData struct {
 	FinalMessage    string      `yaml:"final_message,omitempty"`
 	WriteFiles      []WriteFile `yaml:"write_files,omitempty"`
 	RunCommands     []string    `yaml:"runcmd,omitempty"`
+	// BootCommands are commands you want to run early on in the boot process. These should only
+	// be used for commands that are need early on and running them via RunCommands is too late.
+	BootCommands []string `yaml:"bootcmd,omitempty"`
 }
 
 type User struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding `bootcmd` to the cloud-init user-data so that it can be used by
capmvm to temporaruily fix an issue with dns resolution in our base
images.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
