### PR TITLE
Update the service file to use config.yaml

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,0 +1,5 @@
+---
+containerd-socket: "/run/containerd/containerd.sock"
+grpc-endpoint: "10.25.63.3:9090"
+verbosity: 9
+parent-iface: "bond0"

--- a/flintlockd.service
+++ b/flintlockd.service
@@ -1,4 +1,4 @@
-# Copyright The flintlock Authors
+# Copyright The Flintlock Authors
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,13 +20,7 @@ Requires=containerd.service
 [Service]
 ExecStartPre=which firecracker
 ExecStartPre=which flintlockd
-# The exec start here has placeholders which must be set
-# There will soon be a config file to use instead
-ExecStart=/usr/local/bin/flintlockd run \
-        --containerd-socket=/run/containerd/containerd.sock \
-        --grpc-endpoint=ADDRESS:9090 \
-        --verbosity=9 \
-        --parent-iface=PARENT_IFACE
+ExecStart=/usr/local/bin/flintlockd run
 Restart=always
 RestartSec=5
 User=root

--- a/hack/scripts/README.md
+++ b/hack/scripts/README.md
@@ -36,7 +36,8 @@ COMMANDS:
       --skip-apt, -s     Skip installation of apt packages
       --thinpool, -t     Name of thinpool to create (default: flintlock or flintlock-dev)
       --disk, -d         Name blank unpartioned disk to use for direct lvm thinpool (ignored if --dev set)
-      --grpc-address, -a Address on which to start the GRPC server (default: local ipv4 address)
+      --grpc-address, -a Address on which to start the Flintlock GRPC server (default: local ipv4 address)
+      --parent-iface, -i Interface of the default route of the host
       --dev              Set up development environment. Loop thinpools will be created.
 
   apt                    Install all apt packages required by flintlock
@@ -55,6 +56,7 @@ COMMANDS:
     OPTIONS:
       --version, -v      Version to install (default: latest)
       --grpc-address, -a Address on which to start the GRPC server (default: local ipv4 address)
+      --parent-iface, -i Interface of the default route of the host
       --dev              Assumes containerd has been provisioned in a dev environment
 
   direct_lvm             Set up direct_lvm thinpool


### PR DESCRIPTION
A small change to tidy up both the flintlockd.service and the
provision.sh.
Now we write a configfile for flintlockd rather than sedding flag values
into the service file.
I have also added an example config file in the repo for good measure
