### PR TITLE
Set instance_id in flintlock

### DIFF
--- a/client/cloudinit/cloudinit.go
+++ b/client/cloudinit/cloudinit.go
@@ -1,0 +1,10 @@
+package cloudinit
+
+const (
+	// InstanceDataKey is the metdata key name to use for instance data.
+	InstanceDataKey = "meta-data"
+	// UserdataKey is the metadata key name to use for user data.
+	UserdataKey = "user-data"
+	// VendorDataKey is the metadata key name to use for vendor data.
+	VendorDataKey = "vendor-data"
+)

--- a/client/cloudinit/instance/const.go
+++ b/client/cloudinit/instance/const.go
@@ -1,0 +1,19 @@
+package instance
+
+// These constants represent standard instance metadata key names.
+const (
+	// CloudNameKey is the instance metdata key name representing the cloud name.
+	CloudNameKey = "cloud_name"
+	// InstanceIDKey is the instance metdata key name representing the unique instance id mof the instance.
+	InstanceIDKey = "instance_id"
+	// LocalHostnameKey is the instance metdata key name representing the host name of the instance.
+	LocalHostnameKey = "local_hostname"
+	// PlatformKey is the instance metdata key name representing the hosting platform of the instance.
+	PlatformKey = "platform"
+)
+
+// These constants represents custom instance metadata names
+const (
+	// ClusterNameKey is the instance metdata key name representing the cluster name of the instance.
+	ClusterNameKey = "cluster_name"
+)

--- a/client/cloudinit/instance/metadata.go
+++ b/client/cloudinit/instance/metadata.go
@@ -1,0 +1,80 @@
+package instance
+
+// New creates a new instance metadata
+func New(opts ...MetadataOption) Metadata {
+	m := map[string]string{}
+
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	return m
+}
+
+// Metadata represents the cloud-init instance metadata.
+// See https://cloudinit.readthedocs.io/en/latest/topics/instancedata.html
+type Metadata map[string]string
+
+// HasItem returns true/false if the specific metadata item exists.
+func (m Metadata) HasItem(name string) bool {
+	if len(m) == 0 {
+		return false
+	}
+	_, ok := m[name]
+
+	return ok
+}
+
+// MetadataOption is an option when creating an instance of Metadata
+type MetadataOption func(Metadata)
+
+// WithInstanceID will set the instance id metadata.
+func WithInstanceID(instanceID string) MetadataOption {
+	return func(im Metadata) {
+		im[InstanceIDKey] = instanceID
+	}
+}
+
+// WithCloudName will set the cloud name metadata.
+func WithCloudName(name string) MetadataOption {
+	return func(im Metadata) {
+		im[CloudNameKey] = name
+	}
+}
+
+// WithLocalHostname will set the local hostname metadata.
+func WithLocalHostname(name string) MetadataOption {
+	return func(im Metadata) {
+		im[LocalHostnameKey] = name
+	}
+}
+
+// WithPlatform will set the platform metadata.
+func WithPlatform(name string) MetadataOption {
+	return func(im Metadata) {
+		im[PlatformKey] = name
+	}
+}
+
+// WithClusterName will set the cluster name metadata.
+func WithClusterName(name string) MetadataOption {
+	return func(im Metadata) {
+		im[ClusterNameKey] = name
+	}
+}
+
+// WithExisting will set the metadata keys/values based on an existing Metadata.
+func WithExisting(existing Metadata) MetadataOption {
+	return func(im Metadata) {
+		for k, v := range existing {
+			im[k] = v
+		}
+	}
+}
+
+// WithKeyValue will set the metadata with the specified key and value.
+func WithKeyValue(key, value string) MetadataOption {
+	return func(im Metadata) {
+		im[key] = value
+	}
+}

--- a/client/cloudinit/instance/metadata_test.go
+++ b/client/cloudinit/instance/metadata_test.go
@@ -1,0 +1,71 @@
+package instance_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/weaveworks/flintlock/client/cloudinit/instance"
+)
+
+const (
+	testCloudName    = "nocloud"
+	testClusterName  = "cluster1"
+	testInstanceID   = "i-123456"
+	testHostName     = "host1"
+	testPlatformName = "liquidmetal"
+)
+
+func TestInstanceMetadata_NewNoOptions(t *testing.T) {
+	RegisterTestingT(t)
+
+	m := instance.New()
+	Expect(m).NotTo(BeNil())
+	Expect(m).To(HaveLen(0))
+}
+
+func TestInstanceMetadata_NewWithOptions(t *testing.T) {
+	RegisterTestingT(t)
+
+	m := instance.New(
+		instance.WithCloudName(testCloudName),
+		instance.WithClusterName(testClusterName),
+		instance.WithInstanceID(testInstanceID),
+		instance.WithLocalHostname(testHostName),
+		instance.WithPlatform(testPlatformName),
+	)
+	Expect(m).NotTo(BeNil())
+	Expect(m).To(HaveLen(5))
+
+	Expect(m[instance.CloudNameKey]).To(Equal(testCloudName))
+	Expect(m[instance.ClusterNameKey]).To(Equal(testClusterName))
+	Expect(m[instance.InstanceIDKey]).To(Equal(testInstanceID))
+	Expect(m[instance.LocalHostnameKey]).To(Equal(testHostName))
+	Expect(m[instance.PlatformKey]).To(Equal(testPlatformName))
+}
+
+func TestInstanceMetadata_NewOptionsExisting(t *testing.T) {
+	RegisterTestingT(t)
+
+	existing := instance.New(
+		instance.WithCloudName(testCloudName),
+		instance.WithClusterName(testClusterName),
+		instance.WithInstanceID(testInstanceID),
+		instance.WithLocalHostname(testHostName),
+		instance.WithPlatform(testPlatformName),
+	)
+
+	m := instance.New(
+		instance.WithExisting(existing),
+		instance.WithInstanceID("changed"),
+	)
+
+	Expect(m).NotTo(BeNil())
+	Expect(m).To(HaveLen(5))
+
+	Expect(m[instance.CloudNameKey]).To(Equal(testCloudName))
+	Expect(m[instance.ClusterNameKey]).To(Equal(testClusterName))
+	Expect(m[instance.InstanceIDKey]).To(Equal("changed"))
+	Expect(m[instance.LocalHostnameKey]).To(Equal(testHostName))
+	Expect(m[instance.PlatformKey]).To(Equal(testPlatformName))
+}

--- a/client/cloudinit/metadata.go
+++ b/client/cloudinit/metadata.go
@@ -1,8 +1,0 @@
-package cloudinit
-
-type Metadata struct {
-	InstanceID    string `yaml:"instance_id",json:"instance_id"`
-	LocalHostname string `yaml:"local_hostname",json:"local_hostname"`
-	Platform      string `yaml:"platform",json:"platform"`
-	ClusterName   string `yaml:"cluster_name",json:"cluster_name"`
-}

--- a/client/cloudinit/network/network.go
+++ b/client/cloudinit/network/network.go
@@ -1,4 +1,4 @@
-package cloudinit
+package network
 
 type Network struct {
 	Version  int                 `yaml:"version"`

--- a/client/cloudinit/userdata/userdata.go
+++ b/client/cloudinit/userdata/userdata.go
@@ -1,4 +1,4 @@
-package cloudinit
+package userdata
 
 type UserData struct {
 	HostName        string      `yaml:"hostname,omitempty"`

--- a/client/go.mod
+++ b/client/go.mod
@@ -10,4 +10,5 @@ require (
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	google.golang.org/grpc v1.44.0 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
+	github.com/onsi/gomega v1.18.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -117,4 +117,5 @@ require (
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1620,4 +1620,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/structured-merge-diff/v4 v4.0.3/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
+sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/infrastructure/firecracker/config.go
+++ b/infrastructure/firecracker/config.go
@@ -7,7 +7,7 @@ import (
 	"github.com/firecracker-microvm/firecracker-go-sdk"
 	"gopkg.in/yaml.v3"
 
-	"github.com/weaveworks/flintlock/client/cloudinit"
+	cinetwork "github.com/weaveworks/flintlock/client/cloudinit/network"
 	"github.com/weaveworks/flintlock/core/errors"
 	"github.com/weaveworks/flintlock/core/models"
 	"github.com/weaveworks/flintlock/internal/config"
@@ -192,9 +192,9 @@ func createNetworkIface(iface *models.NetworkInterface, status *models.NetworkIn
 }
 
 func generateNetworkConfig(vm *models.MicroVM) (string, error) {
-	network := &cloudinit.Network{
+	network := &cinetwork.Network{
 		Version:  cloudInitNetVersion,
-		Ethernet: map[string]cloudinit.Ethernet{},
+		Ethernet: map[string]cinetwork.Ethernet{},
 	}
 
 	for i := range vm.Spec.NetworkInterfaces {
@@ -207,8 +207,8 @@ func generateNetworkConfig(vm *models.MicroVM) (string, error) {
 
 		macAddress := getMacAddress(&iface, status)
 
-		eth := &cloudinit.Ethernet{
-			Match: cloudinit.Match{},
+		eth := &cinetwork.Ethernet{
+			Match: cinetwork.Match{},
 			DHCP4: firecracker.Bool(true),
 			DHCP6: firecracker.Bool(true),
 		}
@@ -236,7 +236,7 @@ func generateNetworkConfig(vm *models.MicroVM) (string, error) {
 	return base64.StdEncoding.EncodeToString(nd), nil
 }
 
-func configureStaticEthernet(iface *models.NetworkInterface, eth *cloudinit.Ethernet) error {
+func configureStaticEthernet(iface *models.NetworkInterface, eth *cinetwork.Ethernet) error {
 	eth.Addresses = []string{string(iface.StaticAddress.Address)}
 
 	if iface.StaticAddress.Gateway != nil {
@@ -258,7 +258,7 @@ func configureStaticEthernet(iface *models.NetworkInterface, eth *cloudinit.Ethe
 	}
 
 	if len(iface.StaticAddress.Nameservers) > 0 {
-		eth.Nameservers = cloudinit.Nameservers{
+		eth.Nameservers = cinetwork.Nameservers{
 			Addresses: []string{},
 		}
 

--- a/infrastructure/grpc/convert.go
+++ b/infrastructure/grpc/convert.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/weaveworks/flintlock/api/types"
+	"github.com/weaveworks/flintlock/client/cloudinit/instance"
 	"github.com/weaveworks/flintlock/core/models"
 	"github.com/weaveworks/flintlock/pkg/defaults"
 	"github.com/weaveworks/flintlock/pkg/ptr"
@@ -32,6 +33,7 @@ func convertMicroVMToModel(spec *types.MicroVMSpec) (*models.MicroVM, error) {
 			},
 			VCPU:       int64(spec.Vcpu),
 			MemoryInMb: int64(spec.MemoryInMb),
+			Metadata:   instance.New(),
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This change will set the `instance_id` in the metadata if its not set to the UID for the microvm

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
