### PR TITLE
Pin firecracker to `v0.25.2-macvtap` for nightly e2es

### DIFF
--- a/test/e2e/utils/runner.go
+++ b/test/e2e/utils/runner.go
@@ -23,17 +23,16 @@ import (
 )
 
 const (
-	containerdBin         = "containerd"
-	flintlockCmdDir       = "github.com/weaveworks/flintlock/cmd/flintlockd"
-	containerdSocket      = "/run/containerd-e2e/containerd.sock"
-	containerdCfgDir      = "/etc/containerd/config-e2e.toml"
-	containerdCfg         = containerdCfgDir + "/config-e2e.toml"
-	containerdRootDir     = "/var/lib/containerd-e2e"
-	containerdStateDir    = "/run/containerd-e2e"
-	grpcDialTarget        = "127.0.0.1:9090"
-	loopDeviceTag         = "e2e"
-	containerdGrpcAddress = containerdStateDir + "/containerd.sock"
-	devMapperRoot         = containerdRootDir + "/snapshotter/devmapper"
+	containerdBin      = "containerd"
+	flintlockCmdDir    = "github.com/weaveworks/flintlock/cmd/flintlockd"
+	containerdCfgDir   = "/etc/containerd"
+	containerdRootDir  = "/var/lib/containerd-e2e"
+	containerdStateDir = "/run/containerd-e2e"
+	containerdCfg      = containerdCfgDir + "/config-e2e.toml"
+	containerdSocket   = containerdStateDir + "/containerd.sock"
+	devMapperRoot      = containerdRootDir + "/snapshotter/devmapper"
+	grpcDialTarget     = "127.0.0.1:9090"
+	loopDeviceTag      = "e2e"
 )
 
 // Runner holds test runner configuration.
@@ -156,7 +155,7 @@ func (r *Runner) writeContainerdConfig() {
 		"pool_name":       r.params.ThinpoolName,
 		"root_path":       devMapperRoot,
 		"base_image_size": "10GB",
-		"discard_blocks":  "true",
+		"discard_blocks":  true,
 	}
 	pluginTree, err := toml.TreeFromMap(dmplug)
 	gm.Expect(err).NotTo(gm.HaveOccurred())
@@ -166,7 +165,7 @@ func (r *Runner) writeContainerdConfig() {
 		Root:    containerdRootDir,
 		State:   containerdStateDir,
 		GRPC: ccfg.GRPCConfig{
-			Address: containerdGrpcAddress,
+			Address: containerdSocket,
 		},
 		Metrics: ccfg.MetricsConfig{
 			Address: "127.0.0.1:1338",

--- a/test/tools/config/userdata.sh
+++ b/test/tools/config/userdata.sh
@@ -52,7 +52,7 @@ if [[ -z "$SKIP_DIRECT_LVM" ]]; then
 fi
 
 # install latest firecracker
-./flintlock/hack/scripts/provision.sh firecracker
+./flintlock/hack/scripts/provision.sh firecracker --version v0.25.2-macvtap
 
 # install and setup containerd
 curl -sL https://api.github.com/repos/containerd/containerd/releases/latest 2>/dev/null |


### PR DESCRIPTION
Pin firecracker to v0.25.2-macvtap for e2e tests.

Can be undone after #390 


----------------------

Previously we were writing `"discard_blocks":  "true"` with `true` as a
string in the containerd config generated for the tests.
In recent containerds they are being more strict on type, so
now we set it as a bool.

Also I accidentally messed up the path, and did some weird things with other
vars. Now the containerd config file is written to
`/etc/containerd/config-e2e.toml`
not `/etc/containerd/config-e2e.toml/config-e2e.toml`.

Closes #400 