### PR TITLE
fix: failed to create microvm if machine id is too long

### DIFF
--- a/infrastructure/firecracker/create.go
+++ b/infrastructure/firecracker/create.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/firecracker-microvm/firecracker-go-sdk"
 	"github.com/sirupsen/logrus"
@@ -49,8 +48,7 @@ func (p *fcProvider) Create(ctx context.Context, vm *models.MicroVM) error {
 		return fmt.Errorf("saving firecracker metadata: %w", err)
 	}
 
-	id := strings.ReplaceAll(vm.ID.String(), "/", "-")
-	args := []string{"--id", id, "--boot-timer", "--no-api"}
+	args := []string{"--id", vm.ID.UID(), "--boot-timer", "--no-api"}
 	args = append(args, "--config-file", vmState.ConfigPath())
 	args = append(args, "--metadata", vmState.MetadataPath())
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This changes the firecracker provider to use the unique id on the VMID
for the id of the firecracker instance instead of using the
namespace/name combination. The `--id` that you supply to a firecracker
instance can only be a maximum of 64 characters. This is easily exceeded
witgh the namespace and machine name combination. We use a ULID for the
machine unique identifer internally and this is 26 characters long.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #405 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
